### PR TITLE
feat: desk booking UX overhaul and quota park scoping fix

### DIFF
--- a/backend/src/migrations/024_desk_features.ts
+++ b/backend/src/migrations/024_desk_features.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn('desks', 'features'))) {
+    await knex.schema.alterTable('desks', (table) => {
+      table.text('features').nullable(); // JSON string array, e.g. '["Standing Desk","Dual Monitor"]'
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (await knex.schema.hasColumn('desks', 'features')) {
+    await knex.schema.alterTable('desks', (table) => {
+      table.dropColumn('features');
+    });
+  }
+}

--- a/backend/src/models/desk.model.ts
+++ b/backend/src/models/desk.model.ts
@@ -17,6 +17,7 @@ export class DeskModel {
       is_active: true,
       quota_type: data.quotaType ?? null,
       monthly_quota: data.monthlyQuota ?? null,
+      features: data.features && data.features.length > 0 ? JSON.stringify(data.features) : null,
       created_at: now,
       updated_at: now,
     });
@@ -62,6 +63,9 @@ export class DeskModel {
       is_active: data.isActive !== undefined ? data.isActive : existing.isActive,
       quota_type: 'quotaType' in data ? (data.quotaType ?? null) : existing.quotaType,
       monthly_quota: 'monthlyQuota' in data ? (data.monthlyQuota ?? null) : existing.monthlyQuota,
+      features: 'features' in data
+        ? (data.features != null && data.features.length > 0 ? JSON.stringify(data.features) : null)
+        : (existing.features.length > 0 ? JSON.stringify(existing.features) : null),
       updated_at: new Date().toISOString(),
     });
 
@@ -84,6 +88,10 @@ export class DeskModel {
   }
 
   static mapRow(row: any): Desk {
+    let features: string[] = [];
+    if (row.features) {
+      try { features = JSON.parse(row.features); } catch { features = []; }
+    }
     return {
       id: row.id,
       parkId: row.park_id,
@@ -93,6 +101,7 @@ export class DeskModel {
       isActive: Boolean(row.is_active),
       quotaType: row.quota_type ?? null,
       monthlyQuota: row.monthly_quota ?? null,
+      features,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };

--- a/backend/src/routes/desk.routes.ts
+++ b/backend/src/routes/desk.routes.ts
@@ -63,7 +63,7 @@ router.get('/:id', authenticate, async (req: AuthRequest, res: Response) => {
 // POST /api/desks — create desk (park admin only)
 router.post('/', authenticate, requireParkAdmin, async (req: AuthRequest, res: Response) => {
   try {
-    const { name, description, floor } = req.body;
+    const { name, description, floor, features } = req.body;
 
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
       res.status(400).json({ error: 'Desk name is required' });
@@ -90,11 +90,16 @@ router.post('/', authenticate, requireParkAdmin, async (req: AuthRequest, res: R
       parkId = req.user!.parkId;
     }
 
+    const featuresArr: string[] = Array.isArray(features)
+      ? features.filter((f: any) => typeof f === 'string').slice(0, 20)
+      : [];
+
     const desk = await DeskModel.create({
       name: name.trim(),
       description: description?.trim() || null,
       floor: floor?.trim() || null,
       parkId,
+      features: featuresArr,
     });
 
     auditLog({
@@ -152,6 +157,11 @@ router.put('/:id', authenticate, requireParkAdmin, async (req: AuthRequest, res:
     if ('description' in req.body) updates.description = description?.trim() || null;
     if ('floor' in req.body) updates.floor = floor?.trim() || null;
     if (isActive !== undefined) updates.isActive = isActive;
+    if ('features' in req.body) {
+      updates.features = Array.isArray(req.body.features)
+        ? req.body.features.filter((f: any) => typeof f === 'string').slice(0, 20)
+        : [];
+    }
 
     const updated = await DeskModel.update(req.params.id, updates);
 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -465,6 +465,7 @@ export interface Desk {
   isActive: boolean;
   quotaType: DeskQuotaType | null;
   monthlyQuota: number | null;
+  features: string[];
   createdAt: string;
   updatedAt: string;
 }
@@ -491,6 +492,7 @@ export interface CreateDeskRequest {
   parkId: string;
   quotaType?: DeskQuotaType | null;
   monthlyQuota?: number | null;
+  features?: string[];
 }
 
 export interface CreateDeskBookingRequest {

--- a/frontend/src/components/DatePicker.tsx
+++ b/frontend/src/components/DatePicker.tsx
@@ -1,0 +1,241 @@
+import React, { useState, useCallback, useRef, useEffect, CSSProperties } from 'react';
+import ReactDOM from 'react-dom';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface DatePickerProps {
+  value: string;                    // YYYY-MM-DD or ''
+  onChange: (date: string) => void;
+  placeholder?: string;
+  min?: string;                     // YYYY-MM-DD — earliest selectable (defaults to today)
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function toISO(year: number, month: number, day: number): string {
+  return `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+function firstDayOfWeek(year: number, month: number): number {
+  return new Date(year, month, 1).getDay();
+}
+
+function formatDisplay(iso: string): string {
+  const [year, month, day] = iso.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('en-GB', {
+    weekday: 'short', day: 'numeric', month: 'short', year: 'numeric',
+  });
+}
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+const DAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function DatePicker({
+  value,
+  onChange,
+  placeholder = 'Select date',
+  min,
+}: DatePickerProps) {
+  const earliest = min || todayISO();
+  const today    = todayISO();
+
+  const seedISO    = value || earliest;
+  const [open, setOpen]           = useState(false);
+  const [popupStyle, setPopupStyle] = useState<CSSProperties>({});
+  const [viewYear, setViewYear]   = useState(() => parseInt(seedISO.slice(0, 4), 10));
+  const [viewMonth, setViewMonth] = useState(() => parseInt(seedISO.slice(5, 7), 10) - 1);
+
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  // Sync view when value changes externally
+  useEffect(() => {
+    if (value) {
+      setViewYear(parseInt(value.slice(0, 4), 10));
+      setViewMonth(parseInt(value.slice(5, 7), 10) - 1);
+    }
+  }, [value]);
+
+  // Close on outside click / Escape
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      const popup = document.querySelector('.dp__popup');
+      if (
+        triggerRef.current && !triggerRef.current.contains(e.target as Node) &&
+        popup && !popup.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  // Recalculate popup position on scroll / resize
+  useEffect(() => {
+    if (!open) return;
+    const reposition = () => {
+      if (!triggerRef.current) return;
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPopupStyle({
+        position: 'fixed',
+        top: rect.bottom + 4,
+        left: rect.left,
+        zIndex: 9999,
+      });
+    };
+    reposition();
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+    };
+  }, [open]);
+
+  const handleToggle = () => {
+    if (!open && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPopupStyle({
+        position: 'fixed',
+        top: rect.bottom + 4,
+        left: rect.left,
+        zIndex: 9999,
+      });
+    }
+    setOpen(o => !o);
+  };
+
+  const prevMonth = useCallback(() => {
+    setViewMonth(m => {
+      if (m === 0) { setViewYear(y => y - 1); return 11; }
+      return m - 1;
+    });
+  }, []);
+
+  const nextMonth = useCallback(() => {
+    setViewMonth(m => {
+      if (m === 11) { setViewYear(y => y + 1); return 0; }
+      return m + 1;
+    });
+  }, []);
+
+  const handleDayClick = useCallback((iso: string) => {
+    if (iso < earliest) return;
+    onChange(iso);
+    setOpen(false);
+  }, [earliest, onChange]);
+
+  const totalDays = daysInMonth(viewYear, viewMonth);
+  const startPad  = firstDayOfWeek(viewYear, viewMonth);
+
+  const popup = open ? (
+    <div className="dp__popup" style={popupStyle} role="dialog" aria-label="Date picker" aria-modal="true">
+      {/* Month header — reuses ddp styles */}
+      <div className="ddp__header">
+        <button type="button" className="ddp__nav-btn" onClick={prevMonth} aria-label="Previous month">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M10 12L6 8l4-4" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
+        <span className="ddp__month-label">{MONTH_NAMES[viewMonth]} {viewYear}</span>
+        <button type="button" className="ddp__nav-btn" onClick={nextMonth} aria-label="Next month">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
+      </div>
+
+      {/* Calendar grid — reuses ddp styles */}
+      <div className="ddp__grid" role="grid" aria-label={`${MONTH_NAMES[viewMonth]} ${viewYear}`}>
+        {DAY_LABELS.map(d => (
+          <div key={d} className="ddp__weekday" role="columnheader" aria-label={d}>{d}</div>
+        ))}
+
+        {Array.from({ length: startPad }, (_, i) => (
+          <div key={`pad-${i}`} className="ddp__cell ddp__cell--empty" aria-hidden="true" />
+        ))}
+
+        {Array.from({ length: totalDays }, (_, i) => {
+          const day = i + 1;
+          const iso = toISO(viewYear, viewMonth, day);
+          const isPast     = iso < earliest;
+          const isToday    = iso === today;
+          const isSelected = iso === value;
+
+          const cellClasses = [
+            'ddp__cell',
+            isPast     && 'ddp__cell--past',
+            isToday    && 'ddp__cell--today',
+            isSelected && 'ddp__cell--start',
+            !isPast    && 'ddp__cell--interactive',
+          ].filter(Boolean).join(' ');
+
+          return (
+            <div
+              key={iso}
+              className={cellClasses}
+              role="gridcell"
+              aria-label={`${day} ${MONTH_NAMES[viewMonth]}`}
+              aria-disabled={isPast}
+              aria-selected={isSelected || undefined}
+              tabIndex={isPast ? -1 : 0}
+              onClick={isPast ? undefined : () => handleDayClick(iso)}
+              onKeyDown={isPast ? undefined : (e) => {
+                if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleDayClick(iso); }
+              }}
+            >
+              <span className="ddp__day-inner">{day}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  ) : null;
+
+  return (
+    <div className="dp">
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`dp__trigger${open ? ' dp__trigger--open' : ''}`}
+        onClick={handleToggle}
+        aria-label="Pick a date"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+      >
+        <svg className="dp__icon" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <rect x="1.5" y="3" width="13" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.5"/>
+          <path d="M5 1.5V4M11 1.5V4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+          <path d="M1.5 7h13" stroke="currentColor" strokeWidth="1.5"/>
+        </svg>
+        <span className={value ? '' : 'dp__placeholder'}>
+          {value ? formatDisplay(value) : placeholder}
+        </span>
+      </button>
+
+      {/* Portal: renders at document.body — escapes any overflow:hidden ancestor */}
+      {ReactDOM.createPortal(popup, document.body)}
+    </div>
+  );
+}

--- a/frontend/src/components/DeskDatePicker.tsx
+++ b/frontend/src/components/DeskDatePicker.tsx
@@ -1,0 +1,400 @@
+import React, { useState, useCallback } from 'react';
+import { DeskQuotaStatus } from '../types';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface DeskDatePickerProps {
+  rangeStart: string;          // YYYY-MM-DD — always set (at least today)
+  rangeEnd: string;            // YYYY-MM-DD or '' for single / pending-range
+  dateMode: 'single' | 'range' | 'multi';
+  onDateModeChange: (mode: 'single' | 'range' | 'multi') => void;
+  onRangeChange: (start: string, end: string) => void;
+  multiDates: string[];        // YYYY-MM-DD[] – multi-select mode picks
+  onMultiDatesChange: (dates: string[]) => void;
+  myBookedDates: string[];     // YYYY-MM-DD[] – user's confirmed bookings
+  quota: DeskQuotaStatus | null;
+  quotaNextMonth: DeskQuotaStatus | null;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Returns a YYYY-MM-DD string for the given year/month/day. */
+function toISO(year: number, month: number, day: number): string {
+  return `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+/** Number of days in a given month (0-indexed). */
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+/** Day-of-week (0 = Sun) for the 1st of the month. */
+function firstDayOfWeek(year: number, month: number): number {
+  return new Date(year, month, 1).getDay();
+}
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+const DAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+/** Short human-readable label for a YYYY-MM-DD string. */
+function formatDateLabel(iso: string): string {
+  const [year, month, day] = iso.split('-').map(Number);
+  const d = new Date(year, month - 1, day);
+  return d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
+}
+
+/** Number of calendar days between two ISO strings (inclusive). */
+function daysBetween(start: string, end: string): number {
+  const a = new Date(start + 'T00:00:00');
+  const b = new Date(end + 'T00:00:00');
+  return Math.round((b.getTime() - a.getTime()) / 86_400_000) + 1;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function DeskDatePicker({
+  rangeStart,
+  rangeEnd,
+  dateMode,
+  onDateModeChange,
+  onRangeChange,
+  multiDates,
+  onMultiDatesChange,
+  myBookedDates,
+  quota,
+  quotaNextMonth,
+}: DeskDatePickerProps) {
+
+  // ── View month state ──────────────────────────────────────────────────────
+  const initialISO = rangeStart || todayISO();
+  const [viewYear, setViewYear]   = useState(() => parseInt(initialISO.slice(0, 4), 10));
+  const [viewMonth, setViewMonth] = useState(() => parseInt(initialISO.slice(5, 7), 10) - 1);
+
+  // ── Hover preview state (range mode only) ────────────────────────────────
+  const [hoverDate, setHoverDate] = useState<string | null>(null);
+
+  // ── Quota values ──────────────────────────────────────────────────────────
+  // Always show quota for the current calendar month (not tied to view month).
+  const remaining = quota?.monthlyQuota != null ? quota.remainingThisMonth : null;
+
+  // ── Navigation ────────────────────────────────────────────────────────────
+  const prevMonth = useCallback(() => {
+    setViewMonth(m => {
+      if (m === 0) { setViewYear(y => y - 1); return 11; }
+      return m - 1;
+    });
+  }, []);
+
+  const nextMonth = useCallback(() => {
+    setViewMonth(m => {
+      if (m === 11) { setViewYear(y => y + 1); return 0; }
+      return m + 1;
+    });
+  }, []);
+
+  // ── Click handler ─────────────────────────────────────────────────────────
+  const handleDayClick = useCallback((iso: string) => {
+    if (iso < todayISO()) return;  // past — blocked
+
+    if (dateMode === 'single') {
+      onRangeChange(iso, '');
+      return;
+    }
+
+    if (dateMode === 'multi') {
+      if (multiDates.includes(iso)) {
+        onMultiDatesChange(multiDates.filter(d => d !== iso));
+      } else {
+        onMultiDatesChange([...multiDates, iso].sort());
+      }
+      return;
+    }
+
+    // Range mode:
+    if (!rangeStart || rangeEnd || iso < rangeStart) {
+      onRangeChange(iso, '');
+    } else if (iso === rangeStart) {
+      onRangeChange('', '');
+    } else {
+      onRangeChange(rangeStart, iso);
+    }
+    setHoverDate(null);
+  }, [dateMode, rangeStart, rangeEnd, multiDates, onRangeChange, onMultiDatesChange]);
+
+  // ── Mode switch ───────────────────────────────────────────────────────────
+  const handleModeChange = (mode: 'single' | 'range' | 'multi') => {
+    onDateModeChange(mode);
+    if (mode === 'single') {
+      // Preserve first selected date, drop everything else
+      const seed = multiDates[0] || rangeStart || todayISO();
+      onRangeChange(seed, '');
+      onMultiDatesChange([]);
+    } else if (mode === 'range') {
+      const seed = multiDates[0] || rangeStart || todayISO();
+      onRangeChange(seed, '');
+      onMultiDatesChange([]);
+    } else {
+      // multi — seed from current rangeStart if any
+      onMultiDatesChange(rangeStart ? [rangeStart] : []);
+      onRangeChange(rangeStart || todayISO(), '');
+    }
+  };
+
+  // ── Cell classifier ───────────────────────────────────────────────────────
+  const today = todayISO();
+
+  const visualEnd: string | null = (() => {
+    if (dateMode === 'range' && rangeStart && !rangeEnd && hoverDate && hoverDate >= rangeStart) {
+      return hoverDate;
+    }
+    if (dateMode === 'range' && rangeStart && rangeEnd && rangeEnd >= rangeStart) {
+      return rangeEnd;
+    }
+    return null;
+  })();
+
+  function classifyDay(iso: string): {
+    isPast: boolean;
+    isToday: boolean;
+    isSelected: boolean;
+    isStart: boolean;
+    isEnd: boolean;
+    isMiddle: boolean;
+    isBooked: boolean;
+    isHoverPreview: boolean;
+  } {
+    const isPast  = iso < today;
+    const isToday = iso === today;
+
+    // In multi mode each selected date is a "start" (gets the filled circle)
+    const isStart = dateMode === 'multi'
+      ? multiDates.includes(iso)
+      : iso === rangeStart;
+
+    const isEnd    = dateMode === 'range' && !!rangeEnd && iso === rangeEnd;
+    const isMiddle = dateMode === 'range' && !!rangeStart && !!visualEnd
+      && iso > rangeStart && iso < visualEnd;
+
+    const isHoverPreview = !rangeEnd && dateMode === 'range'
+      && !!rangeStart && !!hoverDate && !!(hoverDate >= rangeStart)
+      && iso > rangeStart && iso < hoverDate;
+
+    const isSelected = isStart || isEnd || isMiddle || isHoverPreview;
+    const isBooked   = myBookedDates.includes(iso);
+
+    return { isPast, isToday, isSelected, isStart, isEnd, isMiddle, isBooked, isHoverPreview };
+  }
+
+  // ── Calendar grid construction ────────────────────────────────────────────
+  const totalDays = daysInMonth(viewYear, viewMonth);
+  const startPad  = firstDayOfWeek(viewYear, viewMonth);
+
+  // ── Selected date summary line ────────────────────────────────────────────
+  const summaryLine: string | null = (() => {
+    if (dateMode === 'multi') {
+      if (multiDates.length === 0) return null;
+      if (multiDates.length === 1) return formatDateLabel(multiDates[0]);
+      return `${multiDates.length} days selected`;
+    }
+    if (!rangeStart) return null;
+    if (dateMode === 'single') return formatDateLabel(rangeStart);
+    if (rangeStart && rangeEnd && rangeEnd >= rangeStart) {
+      const count = daysBetween(rangeStart, rangeEnd);
+      return `${formatDateLabel(rangeStart)} – ${formatDateLabel(rangeEnd)} · ${count} day${count !== 1 ? 's' : ''}`;
+    }
+    if (rangeStart && !rangeEnd) return `${formatDateLabel(rangeStart)} – pick an end date`;
+    return null;
+  })();
+
+  // ── Quota warning for this view-month ─────────────────────────────────────
+  const quotaWarning: string | null = (() => {
+    if (remaining === null || remaining === undefined) return null;
+    if (remaining <= 0) return `0 days remaining this month`;
+    if (remaining <= 3) return `${remaining} day${remaining !== 1 ? 's' : ''} left this month`;
+    return null;
+  })();
+
+  const showClear =
+    (dateMode === 'range' && rangeEnd && rangeEnd >= rangeStart) ||
+    (dateMode === 'multi' && multiDates.length > 0);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  return (
+    <div className="ddp">
+
+      {/* ── Mode toggle ─────────────────────────────────────────────────── */}
+      <div className="ddp__mode-row">
+        <div className="ddp__mode-toggle" role="group" aria-label="Date selection mode">
+          <button
+            type="button"
+            className={`ddp__mode-btn${dateMode === 'single' ? ' ddp__mode-btn--active' : ''}`}
+            onClick={() => handleModeChange('single')}
+          >
+            Single
+          </button>
+          <button
+            type="button"
+            className={`ddp__mode-btn${dateMode === 'range' ? ' ddp__mode-btn--active' : ''}`}
+            onClick={() => handleModeChange('range')}
+          >
+            Range
+          </button>
+          <button
+            type="button"
+            className={`ddp__mode-btn${dateMode === 'multi' ? ' ddp__mode-btn--active' : ''}`}
+            onClick={() => handleModeChange('multi')}
+          >
+            Multi-day
+          </button>
+        </div>
+
+        {/* Quota pill */}
+        {quota && quota.monthlyQuota !== null && remaining !== undefined && remaining !== null && (
+          <span className={`ddp__quota-pill${remaining <= 0 ? ' ddp__quota-pill--empty' : remaining <= 3 ? ' ddp__quota-pill--low' : ''}`}>
+            {remaining <= 0
+              ? 'Quota full'
+              : `${remaining} / ${quota.monthlyQuota} left`}
+          </span>
+        )}
+      </div>
+
+      {/* ── Calendar header ──────────────────────────────────────────────── */}
+      <div className="ddp__header">
+        <button
+          type="button"
+          className="ddp__nav-btn"
+          onClick={prevMonth}
+          aria-label="Previous month"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M10 12L6 8l4-4" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
+
+        <span className="ddp__month-label">
+          {MONTH_NAMES[viewMonth]} {viewYear}
+        </span>
+
+        <button
+          type="button"
+          className="ddp__nav-btn"
+          onClick={nextMonth}
+          aria-label="Next month"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        </button>
+      </div>
+
+      {/* ── Weekday labels + day cells ───────────────────────────────────── */}
+      <div className="ddp__grid" role="grid" aria-label={`${MONTH_NAMES[viewMonth]} ${viewYear}`}>
+        {DAY_LABELS.map(d => (
+          <div key={d} className="ddp__weekday" role="columnheader" aria-label={d}>
+            {d}
+          </div>
+        ))}
+
+        {Array.from({ length: startPad }, (_, i) => (
+          <div key={`pad-${i}`} className="ddp__cell ddp__cell--empty" aria-hidden="true" />
+        ))}
+
+        {Array.from({ length: totalDays }, (_, i) => {
+          const day = i + 1;
+          const iso = toISO(viewYear, viewMonth, day);
+          const {
+            isPast, isToday, isStart, isEnd, isMiddle,
+            isBooked, isHoverPreview,
+          } = classifyDay(iso);
+
+          const isInteractive = !isPast;
+
+          const cellClasses = [
+            'ddp__cell',
+            isPast         && 'ddp__cell--past',
+            isToday        && 'ddp__cell--today',
+            isStart        && 'ddp__cell--start',
+            isEnd          && 'ddp__cell--end',
+            isMiddle       && 'ddp__cell--middle',
+            isHoverPreview && 'ddp__cell--hover-mid',
+            isInteractive  && 'ddp__cell--interactive',
+            (isStart && dateMode === 'range' && (rangeEnd || hoverDate)) && 'ddp__cell--cap-left',
+            (isEnd   && dateMode === 'range') && 'ddp__cell--cap-right',
+          ].filter(Boolean).join(' ');
+
+          return (
+            <div
+              key={iso}
+              className={cellClasses}
+              role="gridcell"
+              aria-label={`${day} ${MONTH_NAMES[viewMonth]}`}
+              aria-disabled={isPast}
+              aria-selected={(isStart || isEnd) || undefined}
+              tabIndex={isInteractive ? 0 : -1}
+              onClick={isInteractive ? () => handleDayClick(iso) : undefined}
+              onMouseEnter={
+                isInteractive && dateMode === 'range' && rangeStart && !rangeEnd
+                  ? () => setHoverDate(iso)
+                  : undefined
+              }
+              onMouseLeave={
+                isInteractive && dateMode === 'range' && rangeStart && !rangeEnd
+                  ? () => setHoverDate(null)
+                  : undefined
+              }
+              onKeyDown={
+                isInteractive
+                  ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleDayClick(iso); } }
+                  : undefined
+              }
+            >
+              <span className="ddp__day-inner">{day}</span>
+              {isBooked && <span className="ddp__booked-dot" aria-label="You have a booking on this day" />}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── Quota warning strip ──────────────────────────────────────────── */}
+      {quotaWarning && (
+        <div className={`ddp__quota-warning${remaining === 0 ? ' ddp__quota-warning--empty' : ''}`} role="status">
+          <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5"/>
+            <path d="M8 5v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+            <circle cx="8" cy="11.5" r="0.75" fill="currentColor"/>
+          </svg>
+          {quotaWarning}
+        </div>
+      )}
+
+      {/* ── Selection summary ────────────────────────────────────────────── */}
+      {(summaryLine || showClear) && (
+        <div className="ddp__summary" aria-live="polite">
+          {summaryLine && <span className="ddp__summary-text">{summaryLine}</span>}
+          {showClear && (
+            <button
+              type="button"
+              className="ddp__clear-btn"
+              onClick={() => {
+                if (dateMode === 'multi') {
+                  onMultiDatesChange([]);
+                } else {
+                  onRangeChange(todayISO(), '');
+                }
+              }}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/AdminDesksPage.tsx
+++ b/frontend/src/pages/AdminDesksPage.tsx
@@ -7,17 +7,22 @@ import { useConfirm } from '../context/ConfirmContext';
 
 type Tab = 'desks' | 'quota' | 'access';
 
-type DeskFormData = { name: string; description: string; floor: string };
-const DEFAULT_DESK_FORM: DeskFormData = { name: '', description: '', floor: '' };
+const COMMON_DESK_FEATURES = [
+  'Standing Desk', 'Dual Monitor', 'Window View', 'Quiet Zone',
+  'Phone', 'External Display', 'Locker', 'Accessible', 'Ergonomic Chair', 'Natural Light',
+];
+
+type DeskFormData = { name: string; description: string; floor: string; features: string[] };
+const DEFAULT_DESK_FORM: DeskFormData = { name: '', description: '', floor: '', features: [] };
 
 const tabClass = (active: boolean) =>
   `tab-btn${active ? ' tab-btn--active' : ''}`;
 
 export function AdminDesksPage() {
-  const { user, isSuperAdmin } = useAuth();
+  const { user } = useAuth();
   const navigate = useNavigate();
   const showConfirm = useConfirm();
-  const parkId = isSuperAdmin ? 'default' : (user?.parkId ?? 'default');
+  const parkId = api.getSelectedParkId() || user?.parkId || 'default';
 
   const getTabFromSearch = (): Tab => {
     const params = new URLSearchParams(window.location.search);
@@ -102,7 +107,7 @@ export function AdminDesksPage() {
 
   const openEdit = (desk: Desk) => {
     setEditingDesk(desk);
-    setDeskForm({ name: desk.name, description: desk.description ?? '', floor: desk.floor ?? '' });
+    setDeskForm({ name: desk.name, description: desk.description ?? '', floor: desk.floor ?? '', features: desk.features ?? [] });
     setDeskError('');
     setShowModal(true);
   };
@@ -113,6 +118,15 @@ export function AdminDesksPage() {
     setDeskForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
   };
 
+  const handleFeatureToggle = (feature: string) => {
+    setDeskForm((prev) => ({
+      ...prev,
+      features: prev.features.includes(feature)
+        ? prev.features.filter((f) => f !== feature)
+        : [...prev.features, feature],
+    }));
+  };
+
   const handleDeskSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setDeskError('');
@@ -121,6 +135,7 @@ export function AdminDesksPage() {
       name: deskForm.name.trim(),
       description: deskForm.description.trim() || null,
       floor: deskForm.floor.trim() || null,
+      features: deskForm.features,
     };
     try {
       if (editingDesk) {
@@ -311,6 +326,16 @@ export function AdminDesksPage() {
                         {desk.description && (
                           <div style={{ fontSize: '0.78rem', color: '#6b7280', marginTop: '2px' }}>
                             {desk.description}
+                          </div>
+                        )}
+                        {desk.features && desk.features.length > 0 && (
+                          <div style={{ marginTop: '3px', display: 'flex', flexWrap: 'wrap', gap: '3px' }}>
+                            {desk.features.slice(0, 3).map((f) => (
+                              <span key={f} className="amenity-tag small">{f}</span>
+                            ))}
+                            {desk.features.length > 3 && (
+                              <span className="amenity-tag small">+{desk.features.length - 3} more</span>
+                            )}
                           </div>
                         )}
                       </td>
@@ -624,6 +649,21 @@ export function AdminDesksPage() {
                     value={deskForm.description} onChange={handleDeskFormChange}
                     maxLength={2000} rows={2} placeholder="Optional notes"
                   />
+                </div>
+                <div className="form-group">
+                  <label>Features</label>
+                  <div className="amenities-grid">
+                    {COMMON_DESK_FEATURES.map((feature) => (
+                      <label key={feature} className="amenity-checkbox">
+                        <input
+                          type="checkbox"
+                          checked={deskForm.features.includes(feature)}
+                          onChange={() => handleFeatureToggle(feature)}
+                        />
+                        <span>{feature}</span>
+                      </label>
+                    ))}
+                  </div>
                 </div>
               </div>
               <div className="modal-footer">

--- a/frontend/src/pages/DesksPage.tsx
+++ b/frontend/src/pages/DesksPage.tsx
@@ -1,29 +1,100 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { format, parseISO } from 'date-fns';
 import { api } from '../services/api';
 import { Desk, DeskBooking, DeskQuotaStatus } from '../types';
 import { useAuth } from '../context/AuthContext';
 import { useConfirm } from '../context/ConfirmContext';
+import { DeskDatePicker } from '../components/DeskDatePicker';
 
 function todayISO(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+type DateSelectionMode = 'single' | 'range' | 'multi';
+
+const DESKS_PER_PAGE = 9;
+
 export function DesksPage() {
   const { user } = useAuth();
   const showConfirm = useConfirm();
   const [desks, setDesks] = useState<Desk[]>([]);
-  const [selectedDate, setSelectedDate] = useState<string>(todayISO());
+  const [dateMode, setDateMode] = useState<DateSelectionMode>('single');
+  const [rangeStart, setRangeStart] = useState<string>(todayISO());
+  const [rangeEnd, setRangeEnd] = useState<string>('');
   const [bookingsForDate, setBookingsForDate] = useState<DeskBooking[]>([]);
   const [myBookings, setMyBookings] = useState<DeskBooking[]>([]);
   const [quota, setQuota] = useState<DeskQuotaStatus | null>(null);
+  const [quotaNextMonth, setQuotaNextMonth] = useState<DeskQuotaStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [accessDenied, setAccessDenied] = useState(false);
   const [bookingDeskId, setBookingDeskId] = useState<string | null>(null);
   const [cancellingId, setCancellingId] = useState<string | null>(null);
   const [bookingErrors, setBookingErrors] = useState<Record<string, string>>({});
+  const [selectedFeatures, setSelectedFeatures] = useState<string[]>([]);
+  const [multiDates, setMultiDates] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [bookingResult, setBookingResult] = useState<{
+    succeeded: string[];
+    failed: Array<{ date: string; error: string }>;
+  } | null>(null);
 
-  const currentMonth = selectedDate.slice(0, 7);
+  // ─── Derived values ───────────────────────────────────────────────────────
+
+  const currentMonth = rangeStart.slice(0, 7);
+
+  const nextMonthKey = (() => {
+    const d = new Date(rangeStart + 'T00:00:00');
+    d.setMonth(d.getMonth() + 1);
+    return d.toISOString().slice(0, 7);
+  })();
+
+  const selectedDates = useMemo(() => {
+    if (dateMode === 'multi') return multiDates;
+    if (dateMode === 'single') return rangeStart ? [rangeStart] : [];
+    if (!rangeStart || !rangeEnd || rangeEnd < rangeStart) return [];
+    const dates: string[] = [];
+    const cursor = new Date(rangeStart + 'T00:00:00');
+    const end = new Date(rangeEnd + 'T00:00:00');
+    while (cursor <= end) {
+      dates.push(cursor.toISOString().slice(0, 10));
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    return dates;
+  }, [dateMode, rangeStart, rangeEnd, multiDates]);
+
+  const totalSelectedDays = selectedDates.length;
+  const selectedDaysThisMonth = selectedDates.filter(d => d.slice(0, 7) === currentMonth).length;
+  const selectedDaysNextMonth = selectedDates.filter(d => d.slice(0, 7) === nextMonthKey).length;
+
+  const effectiveEnd = dateMode === 'range' && rangeEnd && rangeEnd >= rangeStart ? rangeEnd : rangeStart;
+
+  const isOverQuota =
+    (quota !== null && quota.remainingThisMonth !== null && selectedDaysThisMonth > quota.remainingThisMonth) ||
+    (selectedDaysNextMonth > 0 && quotaNextMonth !== null && quotaNextMonth.remainingThisMonth !== null &&
+      selectedDaysNextMonth > quotaNextMonth.remainingThisMonth);
+
+  const allDeskFeatures = [...new Set(desks.flatMap((d) => d.features ?? []))].sort();
+
+  const visibleDesks = useMemo(() => {
+    let result = desks;
+    if (selectedFeatures.length > 0) {
+      result = result.filter((d) => selectedFeatures.every((f) => (d.features ?? []).includes(f)));
+    }
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(
+        (d) => d.name.toLowerCase().includes(q) || (d.floor ?? '').toLowerCase().includes(q)
+      );
+    }
+    return result;
+  }, [desks, selectedFeatures, searchQuery]);
+
+  const totalPages = Math.max(1, Math.ceil(visibleDesks.length / DESKS_PER_PAGE));
+  const safePage = Math.min(currentPage, totalPages);
+  const paginatedDesks = visibleDesks.slice((safePage - 1) * DESKS_PER_PAGE, safePage * DESKS_PER_PAGE);
+
+  // ─── Data loading ─────────────────────────────────────────────────────────
 
   const loadDesks = useCallback(async () => {
     try {
@@ -38,8 +109,8 @@ export function DesksPage() {
     }
   }, []);
 
-  const loadBookingsForDate = useCallback(async (date: string) => {
-    const bookings = await api.getDeskBookingsForPark(date, date);
+  const loadBookingsForRange = useCallback(async (start: string, end: string) => {
+    const bookings = await api.getDeskBookingsForPark(start, end);
     setBookingsForDate(bookings);
   }, []);
 
@@ -57,13 +128,22 @@ export function DesksPage() {
     }
   }, []);
 
+  const loadQuotaNextMonth = useCallback(async (month: string) => {
+    try {
+      const status = await api.getDeskQuotaStatus(month);
+      setQuotaNextMonth(status);
+    } catch {
+      setQuotaNextMonth(null);
+    }
+  }, []);
+
   const loadAll = useCallback(async () => {
     setLoading(true);
     try {
       await Promise.all([
         loadDesks(),
         loadMyBookings(),
-        loadBookingsForDate(selectedDate),
+        loadBookingsForRange(rangeStart, rangeStart),
         loadQuota(currentMonth),
       ]);
     } catch (err) {
@@ -77,27 +157,67 @@ export function DesksPage() {
     loadAll();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Reset to page 1 whenever the filtered list changes
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, selectedFeatures, dateMode, rangeStart, rangeEnd, multiDates]); // eslint-disable-line react-hooks/exhaustive-deps
+
   useEffect(() => {
     if (!loading) {
-      loadBookingsForDate(selectedDate).catch(console.error);
+      // For multi mode use the span from first to last selected date
+      const multiStart = multiDates.length > 0 ? multiDates[0] : rangeStart;
+      const multiEnd   = multiDates.length > 0 ? multiDates[multiDates.length - 1] : rangeStart;
+      const loadStart  = dateMode === 'multi' ? multiStart : rangeStart;
+      const loadEnd    = dateMode === 'multi' ? multiEnd   : effectiveEnd;
+      loadBookingsForRange(loadStart, loadEnd).catch(console.error);
+
+      if (selectedDaysNextMonth > 0 && nextMonthKey !== currentMonth) {
+        loadQuotaNextMonth(nextMonthKey).catch(console.error);
+      } else {
+        setQuotaNextMonth(null);
+      }
     }
-  }, [selectedDate]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [rangeStart, rangeEnd, dateMode, multiDates]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ─── Event handlers ───────────────────────────────────────────────────────
 
   const handleBook = async (desk: Desk) => {
     setBookingDeskId(desk.id);
     setBookingErrors((prev) => ({ ...prev, [desk.id]: '' }));
-    try {
-      await api.createDeskBooking(desk.id, selectedDate);
-      await Promise.all([
-        loadBookingsForDate(selectedDate),
-        loadMyBookings(),
-        loadQuota(currentMonth),
-      ]);
-    } catch (err: any) {
-      setBookingErrors((prev) => ({ ...prev, [desk.id]: err.message || 'Failed to book desk' }));
-    } finally {
-      setBookingDeskId(null);
+    setBookingResult(null);
+
+    const datesToBook = selectedDates.length > 0 ? selectedDates : [rangeStart];
+    const succeeded: string[] = [];
+    const failed: Array<{ date: string; error: string }> = [];
+
+    for (const date of datesToBook) {
+      try {
+        await api.createDeskBooking(desk.id, date);
+        succeeded.push(date);
+      } catch (err: any) {
+        failed.push({ date, error: err.message || 'Failed to book' });
+      }
     }
+
+    if (dateMode === 'range') {
+      setBookingResult({ succeeded, failed });
+    } else if (failed.length > 0) {
+      setBookingErrors((prev) => ({ ...prev, [desk.id]: failed[0].error }));
+    }
+
+    await Promise.all([
+      loadBookingsForRange(rangeStart, effectiveEnd),
+      loadMyBookings(),
+      loadQuota(currentMonth),
+      ...(selectedDaysNextMonth > 0 ? [loadQuotaNextMonth(nextMonthKey)] : []),
+    ]);
+    setBookingDeskId(null);
+  };
+
+  const handleFeatureToggle = (feature: string) => {
+    setSelectedFeatures((prev) =>
+      prev.includes(feature) ? prev.filter((f) => f !== feature) : [...prev, feature]
+    );
   };
 
   const handleCancel = async (bookingId: string) => {
@@ -106,7 +226,7 @@ export function DesksPage() {
     try {
       await api.cancelDeskBooking(bookingId);
       await Promise.all([
-        loadBookingsForDate(selectedDate),
+        loadBookingsForRange(rangeStart, effectiveEnd),
         loadMyBookings(),
         loadQuota(currentMonth),
       ]);
@@ -117,14 +237,11 @@ export function DesksPage() {
     }
   };
 
-  const getBookingForDesk = (deskId: string) =>
-    bookingsForDate.find((b) => b.deskId === deskId && b.status === 'confirmed');
-
   const upcomingMyBookings = myBookings.filter(
     (b) => b.status === 'confirmed' && b.bookingDate >= todayISO()
   );
 
-  const quotaExceeded = quota && quota.remainingThisMonth !== null && quota.remainingThisMonth <= 0;
+  // ─── Render ───────────────────────────────────────────────────────────────
 
   if (loading) {
     return <div className="loading">Loading hot desks...</div>;
@@ -147,100 +264,284 @@ export function DesksPage() {
         <h1>Hot Desks</h1>
       </div>
 
-      {/* Park-wide quota summary */}
-      {quota && quota.monthlyQuota !== null && (
-        <div className="filters" style={{ marginBottom: '1rem' }}>
-          <div className="filter-group">
-            <span style={{ fontWeight: 500 }}>Monthly allowance:</span>{' '}
-            {quota.remainingThisMonth !== null ? (
-              <span style={{ color: quotaExceeded ? '#ef4444' : 'inherit' }}>
-                <strong>{quota.remainingThisMonth}</strong> of {quota.monthlyQuota} day{quota.monthlyQuota !== 1 ? 's' : ''} remaining
-                {quota.quotaType === 'per_company' ? ' (shared with your company)' : ''}
-              </span>
-            ) : (
-              <span>Unlimited</span>
-            )}
-          </div>
-        </div>
-      )}
-
-      <div className="filters">
-        <div className="filter-group">
-          <label>Date:</label>
-          <input
-            type="date"
-            value={selectedDate}
-            min={todayISO()}
-            onChange={(e) => {
-              setSelectedDate(e.target.value);
+      <div className="desks-layout">
+        {/* ── Sidebar: calendar + quota + feature filter ────────────── */}
+        <div className="desks-sidebar">
+          <DeskDatePicker
+            rangeStart={rangeStart}
+            rangeEnd={rangeEnd}
+            dateMode={dateMode}
+            onDateModeChange={(mode) => {
+              setDateMode(mode);
+              if (mode === 'single' || mode === 'range') {
+                setMultiDates([]);
+                if (mode === 'single') setRangeEnd('');
+              }
+              if (mode === 'multi') {
+                setRangeEnd('');
+                setMultiDates(rangeStart ? [rangeStart] : []);
+              }
               setBookingErrors({});
+              setBookingResult(null);
             }}
+            onRangeChange={(start, end) => {
+              setRangeStart(start || todayISO());
+              setRangeEnd(end);
+              setBookingErrors({});
+              setBookingResult(null);
+            }}
+            multiDates={multiDates}
+            onMultiDatesChange={(dates) => {
+              setMultiDates(dates);
+              setBookingErrors({});
+              setBookingResult(null);
+            }}
+            myBookedDates={myBookings.filter(b => b.status === 'confirmed').map(b => b.bookingDate)}
+            quota={quota}
+            quotaNextMonth={quotaNextMonth}
           />
+
+          {/* Desk search */}
+          <div className="desks-search">
+            <input
+              type="search"
+              className="form-input"
+              placeholder="Search by name or location…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              aria-label="Search desks"
+            />
+          </div>
+
+          {/* Quota card — only shown when a real limit is in place */}
+          {quota && quota.monthlyQuota !== null && quota.remainingThisMonth !== null && (
+            <div className="desks-quota-card">
+              <div className="desks-quota-card__header">
+                <span className="desks-quota-card__title">This Month's Quota</span>
+                {quota.quotaType === 'per_company' && (
+                  <span className="desks-quota-card__badge">Shared</span>
+                )}
+              </div>
+
+              <div className="desks-quota-card__main">
+                <span className={[
+                  'desks-quota-card__big-number',
+                  quota.remainingThisMonth === 0 && 'desks-quota-card__big-number--zero',
+                  quota.remainingThisMonth > 0 && quota.remainingThisMonth <= 3 && 'desks-quota-card__big-number--low',
+                ].filter(Boolean).join(' ')}>
+                  {quota.remainingThisMonth}
+                </span>
+                <span className="desks-quota-card__sub">
+                  of {quota.monthlyQuota} day{quota.monthlyQuota !== 1 ? 's' : ''} remaining
+                </span>
+              </div>
+
+              <div
+                className="desks-quota-bar"
+                role="progressbar"
+                aria-valuenow={quota.usedThisMonth}
+                aria-valuemax={quota.monthlyQuota}
+                aria-label={`${quota.usedThisMonth} of ${quota.monthlyQuota} days used`}
+              >
+                <div
+                  className={[
+                    'desks-quota-bar__fill',
+                    quota.remainingThisMonth === 0 && 'desks-quota-bar__fill--full',
+                    quota.remainingThisMonth > 0 && quota.remainingThisMonth <= 3 && 'desks-quota-bar__fill--low',
+                  ].filter(Boolean).join(' ')}
+                  style={{ width: `${Math.min(100, Math.round((quota.usedThisMonth / quota.monthlyQuota) * 100))}%` }}
+                />
+              </div>
+
+              <p className="desks-quota-card__used">
+                {quota.usedThisMonth} used · {quota.remainingThisMonth} left
+              </p>
+
+              {isOverQuota && (
+                <p className="desks-quota-card__warning">
+                  Selection exceeds your remaining quota
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Feature filter */}
+          {allDeskFeatures.length > 0 && (
+            <div className="desks-feature-filter">
+              <p className="desks-feature-filter__label">Filter by features</p>
+              <div className="desks-feature-filter__chips">
+                {allDeskFeatures.map((feature) => (
+                  <label key={feature} className="amenity-checkbox-label">
+                    <input
+                      type="checkbox"
+                      checked={selectedFeatures.includes(feature)}
+                      onChange={() => handleFeatureToggle(feature)}
+                    />
+                    {feature}
+                  </label>
+                ))}
+              </div>
+              {selectedFeatures.length > 0 && (
+                <button
+                  className="btn btn-secondary"
+                  style={{ marginTop: '0.5rem', padding: '0.25rem 0.75rem', fontSize: '0.8125rem' }}
+                  onClick={() => setSelectedFeatures([])}
+                >
+                  Clear filters
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* ── Main: availability grid + booking result ──────────────── */}
+        <div className="desks-main">
+          {/* Booking result banner (range mode) */}
+          {bookingResult && dateMode === 'range' && (
+            <div className={`alert ${bookingResult.failed.length === 0 ? 'alert-success' : bookingResult.succeeded.length === 0 ? 'alert-error' : 'alert-warning'}`}>
+              {bookingResult.succeeded.length > 0 && (
+                <p>Booked {bookingResult.succeeded.length} day{bookingResult.succeeded.length !== 1 ? 's' : ''} successfully.</p>
+              )}
+              {bookingResult.failed.length > 0 && (
+                <p>
+                  Failed on: {bookingResult.failed.map(f => format(parseISO(f.date), 'MMM d')).join(', ')}
+                  {' '}— {bookingResult.failed[0].error}
+                </p>
+              )}
+            </div>
+          )}
+
+          <section className="bookings-section">
+            <h2>
+              {dateMode === 'single' || !rangeEnd || rangeEnd < rangeStart
+                ? `Availability for ${format(parseISO(rangeStart), 'EEEE, MMMM d, yyyy')}`
+                : `Availability — ${format(parseISO(rangeStart), 'MMM d')} to ${format(parseISO(rangeEnd), 'MMM d, yyyy')}`}
+            </h2>
+
+            {visibleDesks.length === 0 ? (
+              <div className="empty-state">
+                <p>
+                  {searchQuery.trim() || selectedFeatures.length > 0
+                    ? 'No desks match your search or filters.'
+                    : 'No hot desks are currently available in your park.'}
+                </p>
+              </div>
+            ) : (
+              <div className="rooms-grid">
+                {paginatedDesks.map((desk) => {
+                  const deskBookings = bookingsForDate.filter(b => b.deskId === desk.id && b.status === 'confirmed');
+                  const booking = deskBookings[0];
+                  const isBookedByMe = dateMode === 'range'
+                    ? deskBookings.some(b => b.userId === user?.id)
+                    : booking?.userId === user?.id;
+                  const isBookedByOther = dateMode === 'range'
+                    ? deskBookings.some(b => b.userId !== user?.id)
+                    : (!!booking && booking.userId !== user?.id);
+                  const bookingError = bookingErrors[desk.id];
+                  const statusLabel = isBookedByMe ? 'Booked by you' : isBookedByOther ? 'Occupied' : 'Available';
+                  const statusClass = isBookedByMe || isBookedByOther ? 'occupied' : 'available';
+
+                  return (
+                    <div key={desk.id} className={`room-card ${statusClass}`}>
+                      <div className="room-card-header">
+                        <h3>{desk.name}</h3>
+                        <span className={`status-badge ${statusClass}`}>{statusLabel}</span>
+                      </div>
+
+                      <div className="room-card-body">
+                        {desk.floor && <p><strong>Location:</strong> {desk.floor}</p>}
+                        {desk.description && <p className="room-description">{desk.description}</p>}
+                        {desk.features && desk.features.length > 0 && (
+                          <div className="room-amenities" style={{ marginTop: '0.5rem' }}>
+                            <div className="amenities-list">
+                              {desk.features.map((f) => (
+                                <span key={f} className="amenity-tag">{f}</span>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                        {bookingError && (
+                          <p style={{ color: '#ef4444', fontSize: '0.875rem', marginTop: '0.5rem' }}>
+                            {bookingError}
+                          </p>
+                        )}
+                      </div>
+
+                      <div className="room-card-footer">
+                        {isBookedByOther ? (
+                          <button className="btn btn-primary" disabled>Occupied</button>
+                        ) : dateMode === 'range' && isBookedByMe ? (
+                          <button className="btn btn-secondary" disabled>Already booked</button>
+                        ) : isBookedByMe ? (
+                          <button
+                            className="btn btn-secondary"
+                            onClick={() => handleCancel(booking!.id)}
+                            disabled={cancellingId === booking!.id}
+                          >
+                            {cancellingId === booking!.id ? 'Cancelling...' : 'Cancel Booking'}
+                          </button>
+                        ) : (
+                          <button
+                            className="btn btn-primary"
+                            onClick={() => handleBook(desk)}
+                            disabled={
+                              bookingDeskId === desk.id ||
+                              !!isOverQuota ||
+                              (dateMode === 'range' && (!rangeEnd || rangeEnd < rangeStart))
+                            }
+                          >
+                            {bookingDeskId === desk.id
+                              ? 'Booking...'
+                              : isOverQuota
+                              ? 'Quota Reached'
+                              : dateMode === 'range' && totalSelectedDays > 1
+                              ? `Book ${totalSelectedDays} Days`
+                              : 'Book Desk'}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="desks-pagination">
+                <button
+                  className="btn btn-secondary desks-pagination__btn"
+                  disabled={safePage <= 1}
+                  onClick={() => setCurrentPage(p => p - 1)}
+                  aria-label="Previous page"
+                >
+                  ‹
+                </button>
+                {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => (
+                  <button
+                    key={page}
+                    className={`desks-pagination__page${page === safePage ? ' desks-pagination__page--active' : ''}`}
+                    onClick={() => setCurrentPage(page)}
+                    aria-current={page === safePage ? 'page' : undefined}
+                  >
+                    {page}
+                  </button>
+                ))}
+                <button
+                  className="btn btn-secondary desks-pagination__btn"
+                  disabled={safePage >= totalPages}
+                  onClick={() => setCurrentPage(p => p + 1)}
+                  aria-label="Next page"
+                >
+                  ›
+                </button>
+              </div>
+            )}
+          </section>
         </div>
       </div>
 
-      <section className="bookings-section">
-        <h2>Availability for {format(parseISO(selectedDate), 'EEEE, MMMM d, yyyy')}</h2>
-
-        {desks.length === 0 ? (
-          <div className="empty-state">
-            <p>No hot desks are currently available in your park.</p>
-          </div>
-        ) : (
-          <div className="rooms-grid">
-            {desks.map((desk) => {
-              const booking = getBookingForDesk(desk.id);
-              const isBookedByMe = booking?.userId === user?.id;
-              const isBookedByOther = !!booking && !isBookedByMe;
-              const bookingError = bookingErrors[desk.id];
-              const statusLabel = isBookedByMe ? 'Booked by you' : isBookedByOther ? 'Occupied' : 'Available';
-              const statusClass = isBookedByMe || isBookedByOther ? 'occupied' : 'available';
-
-              return (
-                <div key={desk.id} className={`room-card ${statusClass}`}>
-                  <div className="room-card-header">
-                    <h3>{desk.name}</h3>
-                    <span className={`status-badge ${statusClass}`}>{statusLabel}</span>
-                  </div>
-
-                  <div className="room-card-body">
-                    {desk.floor && <p><strong>Location:</strong> {desk.floor}</p>}
-                    {desk.description && <p className="room-description">{desk.description}</p>}
-                    {bookingError && (
-                      <p style={{ color: '#ef4444', fontSize: '0.875rem', marginTop: '0.5rem' }}>
-                        {bookingError}
-                      </p>
-                    )}
-                  </div>
-
-                  <div className="room-card-footer">
-                    {isBookedByMe ? (
-                      <button
-                        className="btn btn-secondary"
-                        onClick={() => handleCancel(booking!.id)}
-                        disabled={cancellingId === booking!.id}
-                      >
-                        {cancellingId === booking!.id ? 'Cancelling...' : 'Cancel Booking'}
-                      </button>
-                    ) : isBookedByOther ? (
-                      <button className="btn btn-primary" disabled>Occupied</button>
-                    ) : (
-                      <button
-                        className="btn btn-primary"
-                        onClick={() => handleBook(desk)}
-                        disabled={bookingDeskId === desk.id || !!quotaExceeded}
-                      >
-                        {bookingDeskId === desk.id ? 'Booking...' : quotaExceeded ? 'Quota Reached' : 'Book Desk'}
-                      </button>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </section>
-
+      {/* My Upcoming Bookings — full width, below the two-column layout */}
       <section className="bookings-section">
         <h2>My Upcoming Desk Bookings ({upcomingMyBookings.length})</h2>
 

--- a/frontend/src/pages/RoomsListPage.tsx
+++ b/frontend/src/pages/RoomsListPage.tsx
@@ -2,9 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { api } from '../services/api';
 import { MeetingRoom, Booking } from '../types';
 import { BookingModal } from '../components/BookingModal';
+import { DatePicker } from '../components/DatePicker';
 import { parseISO, isAfter, isBefore } from 'date-fns';
 import { useSettings } from '../context/SettingsContext';
 import { formatTime } from '../utils/time';
+
+const ROOMS_PER_PAGE = 9;
 
 export function RoomsListPage() {
   const [rooms, setRooms] = useState<MeetingRoom[]>([]);
@@ -13,10 +16,12 @@ export function RoomsListPage() {
   const [selectedRoom, setSelectedRoom] = useState<MeetingRoom | null>(null);
   const [filterCapacity, setFilterCapacity] = useState<number>(0);
   const [filterAmenity, setFilterAmenity] = useState<string>('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
 
   // Room Finder state
   const [finderOpen, setFinderOpen] = useState(true);
-  const [finderDate, setFinderDate] = useState('');
+  const [finderDate, setFinderDate] = useState(() => new Date().toISOString().slice(0, 10));
   const [finderStart, setFinderStart] = useState('09:00');
   const [finderEnd, setFinderEnd] = useState('10:00');
   const [finderPeople, setFinderPeople] = useState(1);
@@ -126,12 +131,29 @@ export function RoomsListPage() {
       const start = new Date(`${finderDate}T${finderStart}`);
       const end = new Date(`${finderDate}T${finderEnd}`);
       if (!isRoomAvailableForSlot(room.id, start, end)) return false;
-      return true;
+    } else {
+      if (filterCapacity > 0 && room.capacity < filterCapacity) return false;
+      if (filterAmenity && !room.amenities.includes(filterAmenity)) return false;
     }
-    if (filterCapacity > 0 && room.capacity < filterCapacity) return false;
-    if (filterAmenity && !room.amenities.includes(filterAmenity)) return false;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      if (
+        !room.name.toLowerCase().includes(q) &&
+        !room.floor.toLowerCase().includes(q) &&
+        !room.address.toLowerCase().includes(q)
+      ) return false;
+    }
     return true;
   });
+
+  const totalPages   = Math.max(1, Math.ceil(filteredRooms.length / ROOMS_PER_PAGE));
+  const safePage     = Math.min(currentPage, totalPages);
+  const paginatedRooms = filteredRooms.slice((safePage - 1) * ROOMS_PER_PAGE, safePage * ROOMS_PER_PAGE);
+
+  // Reset to page 1 whenever filters or search change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, filterCapacity, filterAmenity, finderActive]);
 
   if (loading) {
     return (
@@ -163,10 +185,10 @@ export function RoomsListPage() {
             <div className="finder-row">
               <div className="finder-field">
                 <label>Date</label>
-                <input
-                  type="date"
+                <DatePicker
                   value={finderDate}
-                  onChange={e => setFinderDate(e.target.value)}
+                  onChange={setFinderDate}
+                  placeholder="Pick a date"
                 />
               </div>
               <div className="finder-field">
@@ -252,33 +274,50 @@ export function RoomsListPage() {
         )}
       </div>
 
-      {!finderActive && (
-        <div className="filters">
-          <div className="filter-group">
-            <label>Min Capacity:</label>
-            <select value={filterCapacity} onChange={e => setFilterCapacity(Number(e.target.value))}>
-              <option value={0}>Any</option>
-              <option value={4}>4+ people</option>
-              <option value={8}>8+ people</option>
-              <option value={12}>12+ people</option>
-              <option value={20}>20+ people</option>
-            </select>
-          </div>
-
-          <div className="filter-group">
-            <label>Amenity:</label>
-            <select value={filterAmenity} onChange={e => setFilterAmenity(e.target.value)}>
-              <option value="">Any</option>
-              {allAmenities.map(amenity => (
-                <option key={amenity} value={amenity}>{amenity}</option>
-              ))}
-            </select>
+      <div className="filters" style={{ alignItems: 'center' }}>
+        {/* Search — always visible */}
+        <div className="filter-group rooms-search-group">
+          <div className="desks-search" style={{ margin: 0, minWidth: '220px' }}>
+            <input
+              type="search"
+              className="form-input"
+              placeholder="Search by name, floor or address…"
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              aria-label="Search rooms"
+            />
           </div>
         </div>
-      )}
+
+        {/* Standard filters — hidden while finder is active */}
+        {!finderActive && (
+          <>
+            <div className="filter-group">
+              <label>Min Capacity:</label>
+              <select value={filterCapacity} onChange={e => setFilterCapacity(Number(e.target.value))}>
+                <option value={0}>Any</option>
+                <option value={4}>4+ people</option>
+                <option value={8}>8+ people</option>
+                <option value={12}>12+ people</option>
+                <option value={20}>20+ people</option>
+              </select>
+            </div>
+
+            <div className="filter-group">
+              <label>Amenity:</label>
+              <select value={filterAmenity} onChange={e => setFilterAmenity(e.target.value)}>
+                <option value="">Any</option>
+                {allAmenities.map(amenity => (
+                  <option key={amenity} value={amenity}>{amenity}</option>
+                ))}
+              </select>
+            </div>
+          </>
+        )}
+      </div>
 
       <div className="rooms-grid">
-        {filteredRooms.map(room => {
+        {paginatedRooms.map(room => {
           const isAvailable = isRoomAvailableNow(room.id);
           const currentBooking = getCurrentBooking(room.id);
           const nextBooking = getNextBooking(room.id);
@@ -355,10 +394,45 @@ export function RoomsListPage() {
 
       {filteredRooms.length === 0 && (
         <div className="empty-state">
-          {finderActive
-            ? <p>No rooms available for this time slot matching your criteria.</p>
-            : <p>No rooms match your filters.</p>
-          }
+          <p>
+            {finderActive
+              ? 'No rooms available for this time slot matching your criteria.'
+              : searchQuery.trim()
+              ? 'No rooms match your search.'
+              : 'No rooms match your filters.'}
+          </p>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="desks-pagination">
+          <button
+            className="btn btn-secondary desks-pagination__btn"
+            disabled={safePage <= 1}
+            onClick={() => setCurrentPage(p => p - 1)}
+            aria-label="Previous page"
+          >
+            ‹
+          </button>
+          {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => (
+            <button
+              key={page}
+              className={`desks-pagination__page${page === safePage ? ' desks-pagination__page--active' : ''}`}
+              onClick={() => setCurrentPage(page)}
+              aria-current={page === safePage ? 'page' : undefined}
+            >
+              {page}
+            </button>
+          ))}
+          <button
+            className="btn btn-secondary desks-pagination__btn"
+            disabled={safePage >= totalPages}
+            onClick={() => setCurrentPage(p => p + 1)}
+            aria-label="Next page"
+          >
+            ›
+          </button>
         </div>
       )}
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -49,6 +49,7 @@
   --space-8:  2rem;
 
   /* Border radius */
+  --radius:      0.375rem;   /* alias for --radius-md, used throughout */
   --radius-sm:   0.25rem;
   --radius-md:   0.375rem;
   --radius-lg:   0.5rem;
@@ -631,30 +632,42 @@ body {
 }
 
 /* ── Room Finder panel ───────────────────────────────────────────────────── */
-[data-theme="dark"] .room-finder-panel {
-  border-color: var(--border-color);
-}
-
-[data-theme="dark"] .finder-toggle {
-  background: var(--color-surface-2);
-  color: var(--color-text);
-}
-
 [data-theme="dark"] .finder-toggle:hover {
   background: var(--color-input-bg);
 }
 
-[data-theme="dark"] .finder-form {
-  border-top-color: var(--border-color);
+[data-theme="dark"] .finder-active-badge {
+  background: rgba(16, 185, 129, 0.15);
+  color: #6ee7b7;
+}
+
+[data-theme="dark"] .finder-status {
+  background: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.25);
+  color: var(--color-text-muted);
+}
+
+[data-theme="dark"] .finder-field input {
+  background: var(--color-input-bg);
+  border-color: var(--border-color);
+  color: var(--color-text);
 }
 
 [data-theme="dark"] .amenity-checkbox-label {
+  background: var(--color-input-bg);
   border-color: var(--border-color);
   color: var(--color-text);
 }
 
 [data-theme="dark"] .amenity-checkbox-label:hover {
-  background: var(--color-input-bg);
+  background: var(--color-gray-200);
+  border-color: var(--color-primary);
+}
+
+[data-theme="dark"] .amenity-checkbox-label:has(input:checked) {
+  background: rgba(99, 102, 241, 0.18);
+  border-color: var(--color-primary);
+  color: var(--color-primary-hover);
 }
 
 /* ── Mobile room selector ────────────────────────────────────────────────── */
@@ -1954,10 +1967,11 @@ body {
 
 /* Room Finder */
 .room-finder-panel {
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-lg);
   margin-bottom: 1.5rem;
   overflow: hidden;
+  background: var(--color-surface);
 }
 
 .finder-toggle {
@@ -1966,23 +1980,23 @@ body {
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1rem;
-  background: var(--color-gray-50);
+  background: var(--color-surface-2);
   border: none;
   cursor: pointer;
   font-size: 0.9375rem;
   font-weight: 600;
-  color: var(--color-gray-700);
+  color: var(--color-text);
   text-align: left;
   transition: background 0.15s;
 }
 
 .finder-toggle:hover {
-  background: #e5e7eb;
+  background: var(--color-gray-100);
 }
 
 .finder-toggle-icon {
   font-size: 0.75rem;
-  color: var(--color-gray-400);
+  color: var(--color-text-muted);
 }
 
 .finder-active-badge {
@@ -1990,14 +2004,15 @@ body {
   font-size: 0.75rem;
   font-weight: 500;
   padding: 0.125rem 0.5rem;
-  background: #d1fae5;
-  color: #065f46;
+  background: var(--color-success-light, #d1fae5);
+  color: var(--color-success-text, #065f46);
   border-radius: 9999px;
 }
 
 .finder-form {
   padding: 1rem;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid var(--border-color);
+  background: var(--color-surface);
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -2019,14 +2034,24 @@ body {
 .finder-field label {
   font-size: 0.8125rem;
   font-weight: 500;
-  color: var(--color-gray-600);
+  color: var(--color-text-muted);
 }
 
 .finder-field input {
-  padding: 0.5rem;
-  border: 1px solid #d1d5db;
+  padding: 0.5rem 0.625rem;
+  background: var(--color-input-bg);
+  border: 1px solid var(--color-gray-300);
   border-radius: var(--radius);
   font-size: 0.875rem;
+  font-family: inherit;
+  color: var(--color-text);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.finder-field input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
 .finder-amenities {
@@ -2038,7 +2063,7 @@ body {
 .finder-amenities > label {
   font-size: 0.8125rem;
   font-weight: 500;
-  color: var(--color-gray-600);
+  color: var(--color-text-muted);
 }
 
 .amenity-checkboxes {
@@ -2053,18 +2078,29 @@ body {
   gap: 0.375rem;
   font-size: 0.875rem;
   cursor: pointer;
-  padding: 0.25rem 0.625rem;
-  border: 1px solid #d1d5db;
+  padding: 0.3rem 0.75rem;
+  background: var(--color-surface-2);
+  border: 1px solid var(--border-color);
   border-radius: 9999px;
+  color: var(--color-text);
   transition: background 0.15s, border-color 0.15s;
 }
 
 .amenity-checkbox-label:hover {
-  background: var(--color-gray-50);
+  background: var(--color-gray-100);
+  border-color: var(--color-primary);
+}
+
+.amenity-checkbox-label:has(input:checked) {
+  background: var(--color-primary-lighter);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  font-weight: 500;
 }
 
 .amenity-checkbox-label input[type="checkbox"] {
   margin: 0;
+  accent-color: var(--color-primary);
 }
 
 .finder-actions {
@@ -2075,11 +2111,11 @@ body {
 
 .finder-status {
   font-size: 0.875rem;
-  color: var(--color-gray-600);
+  color: var(--color-text-muted);
   margin: 0;
   padding: 0.5rem 0.75rem;
-  background: #f0fdf4;
-  border: 1px solid #bbf7d0;
+  background: var(--color-success-light, #f0fdf4);
+  border: 1px solid var(--color-success-border, #bbf7d0);
   border-radius: var(--radius);
 }
 
@@ -2096,16 +2132,79 @@ body {
   gap: 0.5rem;
 }
 
+/* ── Desk date selection widget ── */
+.desk-date-filters { align-items: center; }
+
+.desk-date-mode-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.desk-date-mode-btn {
+  padding: 0.375rem 0.875rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+.desk-date-mode-btn:hover:not(.desk-date-mode-btn--active) {
+  background: var(--color-gray-100);
+  color: var(--color-text);
+}
+.desk-date-mode-btn--active {
+  background: var(--color-primary);
+  color: #fff;
+}
+.desk-date-range-group { flex-wrap: wrap; gap: 0.5rem; }
+.desk-date-range-sep {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  padding: 0 0.125rem;
+  align-self: center;
+}
+.desk-date-summary { flex-direction: column; align-items: flex-start; gap: 0.25rem; }
+.desk-date-count { font-size: 0.875rem; font-weight: 500; }
+.desk-date-count--over { color: var(--color-danger, #ef4444); }
+.desk-date-over-quota {
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.2rem 0.6rem;
+  background: #fee2e2;
+  color: #b91c1c;
+  border-radius: 9999px;
+}
+@media (max-width: 640px) {
+  .desk-date-range-group { flex-direction: column; align-items: flex-start; width: 100%; }
+  .desk-date-range-group input[type="date"] { width: 100%; }
+  .desk-date-range-sep { display: none; }
+}
+
 .filter-group label {
   font-size: 0.875rem;
   font-weight: 500;
 }
 
 .filter-group select {
-  padding: 0.5rem;
-  border: 1px solid #d1d5db;
-  border-radius: 0.375rem;
+  padding: 0.4rem 0.625rem;
+  background: var(--color-input-bg);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
+  font-family: inherit;
+  color: var(--color-text);
+  transition: border-color 0.2s, box-shadow 0.2s;
+  cursor: pointer;
+}
+
+.filter-group select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
 .rooms-grid {
@@ -4491,6 +4590,12 @@ body {
 
   .filter-group {
     width: 100%;
+    justify-content: center;
+  }
+
+  .rooms-search-group .desks-search {
+    width: 100%;
+    margin: 0;
   }
 
   .filter-group select {
@@ -5061,3 +5166,956 @@ body {
   background: white;
   min-height: 60px;
 }
+
+/* ============================================================
+   DeskDatePicker — inline calendar component
+   BEM-style: .ddp = block root
+   ============================================================ */
+
+/* ── Root container ─────────────────────────────────────────────────────── */
+.ddp {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: 0.75rem 0.875rem 0.625rem;
+  width: 100%;
+  max-width: 320px;
+  user-select: none;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+}
+
+/* ── Mode toggle row ────────────────────────────────────────────────────── */
+.ddp__mode-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.ddp__mode-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.ddp__mode-btn {
+  padding: 0.3125rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.ddp__mode-btn:hover:not(.ddp__mode-btn--active) {
+  background: var(--color-gray-100);
+  color: var(--color-text);
+}
+
+.ddp__mode-btn--active {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+/* ── Quota pill ─────────────────────────────────────────────────────────── */
+.ddp__quota-pill {
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.1875rem 0.5rem;
+  border-radius: 9999px;
+  background: var(--color-primary-lighter);
+  color: var(--color-primary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.ddp__quota-pill--low {
+  background: var(--color-warning-light);
+  color: var(--color-warning-hover);
+}
+
+.ddp__quota-pill--empty {
+  background: var(--color-danger-light);
+  color: var(--color-danger-hover);
+}
+
+/* ── Calendar header (month label + nav buttons) ─────────────────────────── */
+.ddp__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.ddp__month-label {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+
+.ddp__nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  flex-shrink: 0;
+}
+
+.ddp__nav-btn:hover {
+  background: var(--color-gray-100);
+  color: var(--color-text);
+  border-color: var(--color-gray-300);
+}
+
+.ddp__nav-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/* ── 7-column grid ──────────────────────────────────────────────────────── */
+.ddp__grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  /* No column gap — range background spans cell-to-cell flush */
+  gap: 0;
+  margin-bottom: 0.25rem;
+}
+
+/* ── Weekday header row ─────────────────────────────────────────────────── */
+.ddp__weekday {
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* ── Day cell base ──────────────────────────────────────────────────────── */
+.ddp__cell {
+  position: relative;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: default;
+  /* Range background fills the full cell width/height */
+  background: transparent;
+}
+
+.ddp__cell--empty {
+  pointer-events: none;
+}
+
+/* ── Interactive state ───────────────────────────────────────────────────── */
+.ddp__cell--interactive {
+  cursor: pointer;
+}
+
+.ddp__cell--interactive:hover .ddp__day-inner {
+  background: var(--color-gray-100);
+}
+
+.ddp__cell--interactive:focus-visible {
+  outline: none;
+}
+
+.ddp__cell--interactive:focus-visible .ddp__day-inner {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 0;
+}
+
+/* ── Day inner — the circular/pill click target ─────────────────────────── */
+.ddp__day-inner {
+  position: relative;
+  z-index: 1;            /* sit above range-band pseudo-element */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: var(--color-text);
+  transition: background 0.12s, color 0.12s;
+  line-height: 1;
+}
+
+/* ── Past days ──────────────────────────────────────────────────────────── */
+.ddp__cell--past .ddp__day-inner {
+  color: var(--color-gray-400);
+  cursor: not-allowed;
+}
+
+.ddp__cell--past:hover .ddp__day-inner {
+  background: transparent;
+}
+
+/* ── Today indicator ────────────────────────────────────────────────────── */
+.ddp__cell--today .ddp__day-inner {
+  font-weight: 600;
+}
+
+/* Today ring: thin border on the inner circle when NOT selected */
+.ddp__cell--today:not(.ddp__cell--start):not(.ddp__cell--end):not(.ddp__cell--middle):not(.ddp__cell--hover-mid) .ddp__day-inner {
+  box-shadow: 0 0 0 1.5px var(--color-primary);
+  color: var(--color-primary);
+}
+
+/* ── Selected single / range start & end ────────────────────────────────── */
+.ddp__cell--start .ddp__day-inner,
+.ddp__cell--end .ddp__day-inner {
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 600;
+}
+
+.ddp__cell--start:hover .ddp__day-inner,
+.ddp__cell--end:hover .ddp__day-inner {
+  background: var(--color-primary-hover);
+}
+
+/* ── Range middle fill (the continuous band) ─────────────────────────────
+   We use a ::before pseudo-element on each middle cell to draw a full-width
+   band, and let the .ddp__day-inner circle sit above it.              */
+.ddp__cell--middle,
+.ddp__cell--hover-mid {
+  background: transparent;
+}
+
+.ddp__cell--middle::before,
+.ddp__cell--hover-mid::before {
+  content: '';
+  position: absolute;
+  inset: 3px 0;           /* 3px top/bottom — gives a short pill height */
+  background: var(--color-primary-lighter);
+  z-index: 0;
+}
+
+.ddp__cell--middle .ddp__day-inner,
+.ddp__cell--hover-mid .ddp__day-inner {
+  background: transparent;
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+.ddp__cell--hover-mid::before {
+  /* Slightly more transparent for the hover preview */
+  background: color-mix(in srgb, var(--color-primary-lighter) 65%, transparent);
+}
+
+/* ── Range end-cap modifiers ────────────────────────────────────────────
+   The band on a start-cap cell only extends rightward (flush left).
+   The band on an end-cap cell only extends leftward (flush right).
+   We clip the ::before band using a half-width inset.                  */
+
+/* Start cap: band runs from cell-centre rightward */
+.ddp__cell--cap-left::before {
+  content: '';
+  position: absolute;
+  inset: 3px 0 3px 50%;   /* left edge at 50%, right edge flush */
+  background: var(--color-primary-lighter);
+  z-index: 0;
+}
+
+/* End cap: band runs from left edge to cell-centre */
+.ddp__cell--cap-right::before {
+  content: '';
+  position: absolute;
+  inset: 3px 50% 3px 0;   /* right edge at 50%, left edge flush */
+  background: var(--color-primary-lighter);
+  z-index: 0;
+}
+
+/* ── Already-booked dot ─────────────────────────────────────────────────── */
+.ddp__booked-dot {
+  position: absolute;
+  bottom: 3px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* When the day is selected, the dot becomes white so it stays visible */
+.ddp__cell--start .ddp__booked-dot,
+.ddp__cell--end .ddp__booked-dot {
+  background: rgba(255, 255, 255, 0.8);
+}
+
+/* ── Quota warning strip ─────────────────────────────────────────────────── */
+.ddp__quota-warning {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-warning-hover);
+  background: var(--color-warning-light);
+  border-radius: var(--radius-md);
+  padding: 0.3125rem 0.625rem;
+  margin-top: 0.375rem;
+}
+
+.ddp__quota-warning--empty {
+  color: var(--color-danger-hover);
+  background: var(--color-danger-light);
+}
+
+/* ── Selected date summary bar ───────────────────────────────────────────── */
+.ddp__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.625rem;
+  padding-top: 0.625rem;
+  border-top: 1px solid var(--border-color);
+  min-height: 28px;
+}
+
+.ddp__summary-text {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-text);
+  line-height: 1.4;
+}
+
+.ddp__clear-btn {
+  flex-shrink: 0;
+  padding: 0.1875rem 0.5625rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: var(--color-gray-200);
+  color: var(--color-gray-700);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 0.15s;
+  line-height: 1.4;
+}
+
+.ddp__clear-btn:hover {
+  background: var(--color-gray-300);
+}
+
+/* ── Dark mode overrides ─────────────────────────────────────────────────── */
+[data-theme="dark"] .ddp {
+  background: var(--color-surface);
+  /* Subtle primary glow on the card border so it reads as a focused picker */
+  border-color: color-mix(in srgb, var(--color-primary) 35%, var(--border-color));
+}
+
+/* ── Range band: dark mode needs a much stronger fill than --color-primary-lighter.
+   In dark mode that token is #1e1b4b — virtually indistinguishable from the
+   #1e293b card surface.  We use a direct rgba of the primary accent instead,
+   giving a clearly visible tinted stripe without competing with the filled
+   start/end circles.                                                          */
+[data-theme="dark"] .ddp__cell--middle::before,
+[data-theme="dark"] .ddp__cell--cap-left::before,
+[data-theme="dark"] .ddp__cell--cap-right::before {
+  /* ~32% opacity indigo on the dark card = clearly visible band */
+  background: rgba(99, 102, 241, 0.32);
+}
+
+[data-theme="dark"] .ddp__cell--hover-mid::before {
+  /* Slightly lighter for the hover preview — distinguishable from confirmed range */
+  background: rgba(99, 102, 241, 0.18);
+}
+
+/* Middle-day text: use the lighter primary accent in dark mode so it
+   remains readable on the tinted band without being as loud as start/end */
+[data-theme="dark"] .ddp__cell--middle .ddp__day-inner,
+[data-theme="dark"] .ddp__cell--hover-mid .ddp__day-inner {
+  color: var(--color-primary-hover); /* #818cf8 — brighter than primary on dark bg */
+}
+
+/* Today ring: keep it visible but clearly secondary to the filled start/end */
+[data-theme="dark"] .ddp__cell--today:not(.ddp__cell--start):not(.ddp__cell--end):not(.ddp__cell--middle):not(.ddp__cell--hover-mid) .ddp__day-inner {
+  box-shadow: 0 0 0 2px var(--color-primary-hover);
+  color: var(--color-primary-hover);
+}
+
+[data-theme="dark"] .ddp__cell--interactive:hover .ddp__day-inner {
+  background: var(--color-gray-200);
+}
+
+[data-theme="dark"] .ddp__clear-btn {
+  background: var(--color-gray-200);
+  color: var(--color-gray-700);
+}
+
+[data-theme="dark"] .ddp__clear-btn:hover {
+  background: var(--color-gray-300);
+}
+
+/* ── Reduced-motion ──────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .ddp__day-inner,
+  .ddp__mode-btn,
+  .ddp__nav-btn,
+  .ddp__clear-btn {
+    transition: none;
+  }
+}
+
+/* ── Responsive: on small viewports the picker goes full-width ────────────── */
+@media (max-width: 400px) {
+  .ddp {
+    max-width: 100%;
+    padding: 0.625rem 0.5rem;
+  }
+
+  .ddp__day-inner {
+    width: 30px;
+    height: 30px;
+    font-size: 0.8125rem;
+  }
+
+  .ddp__cell {
+    height: 34px;
+  }
+}
+/* ── System-pref dark: same band + today overrides for users without
+   an explicit data-theme attribute on <html>.
+   Mirrors [data-theme="dark"] .ddp rules above.                       */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .ddp {
+    border-color: color-mix(in srgb, #6366f1 35%, #475569);
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .ddp__cell--middle::before,
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .ddp__cell--cap-left::before,
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .ddp__cell--cap-right::before {
+    background: rgba(99, 102, 241, 0.32);
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .ddp__cell--hover-mid::before {
+    background: rgba(99, 102, 241, 0.18);
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .ddp__cell--middle .ddp__day-inner,
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .ddp__cell--hover-mid .ddp__day-inner {
+    color: #818cf8;
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .ddp__cell--today:not(.ddp__cell--start):not(.ddp__cell--end):not(.ddp__cell--middle):not(.ddp__cell--hover-mid) .ddp__day-inner {
+    box-shadow: 0 0 0 2px #818cf8;
+    color: #818cf8;
+  }
+}
+
+/* ── End DeskDatePicker ─────────────────────────────────────────────────── */
+
+/* ═══════════════════════════════════════════
+   DatePicker  (.dp)
+   Trigger button + floating calendar popup.
+   Calendar grid reuses .ddp__* classes.
+═══════════════════════════════════════════ */
+
+.dp {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+/* ── Trigger (looks like a styled input) ───────────────────────────────── */
+.dp__trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  background: var(--color-input-bg);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-family: inherit;
+  color: var(--color-text);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.dp__trigger:hover {
+  border-color: var(--color-primary);
+}
+
+.dp__trigger--open {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
+}
+
+.dp__icon {
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+}
+
+.dp__placeholder {
+  color: var(--color-text-muted);
+}
+
+/* ── Popup card — rendered via portal at document.body (position:fixed via inline style) */
+.dp__popup {
+  background: var(--color-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: 0.75rem 0.875rem 0.625rem;
+  min-width: 280px;
+  user-select: none;
+}
+
+/* Dark mode trigger */
+[data-theme="dark"] .dp__trigger {
+  background: var(--color-input-bg);
+  border-color: var(--border-color);
+  color: var(--color-text);
+}
+
+[data-theme="dark"] .dp__trigger:hover,
+[data-theme="dark"] .dp__trigger--open {
+  border-color: var(--color-primary);
+}
+
+/* System-pref dark mirror */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .dp__trigger {
+    background: #334155;
+    border-color: #475569;
+    color: #f1f5f9;
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .dp__trigger:hover,
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .dp__trigger--open {
+    border-color: #6366f1;
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .dp__popup {
+    background: #1e293b;
+    border-color: #475569;
+  }
+}
+
+/* ── End DatePicker ─────────────────────────────────────────────────────── */
+
+/* ═══════════════════════════════════════════
+   Desks page two-column layout
+   Sidebar: calendar + quota + feature filter
+   Main:    availability grid
+═══════════════════════════════════════════ */
+
+.desks-layout {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 1.5rem;
+  align-items: start;
+  margin-bottom: 2rem;
+}
+
+/* Sidebar sticks while the desk grid scrolls */
+.desks-sidebar {
+  position: sticky;
+  top: 1rem;
+  align-self: start;
+}
+
+/* Prevent grid blowout on narrow content */
+.desks-main {
+  min-width: 0;
+}
+
+/* ── Quota card (inside sidebar) ───────────────────────────────────────── */
+.desks-quota-card {
+  background: var(--color-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 0.875rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.desks-quota-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.625rem;
+}
+
+.desks-quota-card__title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+
+.desks-quota-card__badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  background: var(--color-primary-lighter);
+  color: var(--color-primary);
+  border-radius: var(--radius-full);
+}
+
+.desks-quota-card__main {
+  display: flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  margin-bottom: 0.625rem;
+}
+
+/* Big remaining-days number */
+.desks-quota-card__big-number {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--color-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.desks-quota-card__big-number--low {
+  color: #f59e0b;
+}
+
+.desks-quota-card__big-number--zero {
+  color: #ef4444;
+}
+
+.desks-quota-card__sub {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+
+/* Progress bar */
+.desks-quota-bar {
+  height: 6px;
+  background: var(--color-gray-200);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  margin-bottom: 0.375rem;
+}
+
+.desks-quota-bar__fill {
+  height: 100%;
+  background: var(--color-primary);
+  border-radius: var(--radius-full);
+  transition: width 0.4s ease;
+  min-width: 0;
+}
+
+.desks-quota-bar__fill--low {
+  background: #f59e0b;
+}
+
+.desks-quota-bar__fill--full {
+  background: #ef4444;
+}
+
+.desks-quota-card__used {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.desks-quota-card__warning {
+  margin-top: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #ef4444;
+}
+
+/* Dark mode */
+[data-theme="dark"] .desks-quota-card__badge {
+  background: rgba(99, 102, 241, 0.15);
+  color: var(--color-primary-hover);
+}
+
+[data-theme="dark"] .desks-quota-bar {
+  background: var(--color-gray-200);
+}
+
+/* System-pref dark */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .desks-quota-card__badge {
+    background: rgba(99, 102, 241, 0.15);
+    color: #818cf8;
+  }
+}
+
+/* ── Feature filter (inside sidebar) ───────────────────────────────────── */
+.desks-feature-filter {
+  background: var(--color-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 0.75rem 0.875rem;
+}
+
+.desks-feature-filter__label {
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  margin: 0 0 0.5rem;
+}
+
+.desks-feature-filter__chips {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────────── */
+
+/* Tablet: slightly narrower sidebar */
+@media (min-width: 769px) and (max-width: 1024px) {
+  .desks-layout {
+    grid-template-columns: 280px 1fr;
+    gap: 1.25rem;
+  }
+}
+
+/* Mobile: single column, sidebar no longer sticky */
+@media (max-width: 768px) {
+  .desks-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .desks-sidebar {
+    position: static;
+  }
+}
+
+/* ── Shared form-input utility ──────────────────────────────────────────── */
+/* Used anywhere a plain input needs styling outside of a .form-group wrapper */
+.form-input {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-input-bg);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-family: inherit;
+  line-height: 1.5;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
+}
+
+/* Dark mode: inherited from the global [data-theme="dark"] input rule */
+
+/* ── Desk search ────────────────────────────────────────────────────────── */
+.desks-search {
+  position: relative;
+  margin-top: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+/* Magnifier icon via inset padding */
+.desks-search::before {
+  content: '';
+  position: absolute;
+  left: 0.65rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  background: currentColor;
+  opacity: 0.4;
+  pointer-events: none;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none'%3E%3Ccircle cx='6.5' cy='6.5' r='4.5' stroke='currentColor' strokeWidth='1.5'/%3E%3Cpath d='M10 10l3 3' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round'/%3E%3C/svg%3E") no-repeat center / contain;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none'%3E%3Ccircle cx='6.5' cy='6.5' r='4.5' stroke='currentColor' strokeWidth='1.5'/%3E%3Cpath d='M10 10l3 3' stroke='currentColor' strokeWidth='1.5' strokeLinecap='round'/%3E%3C/svg%3E") no-repeat center / contain;
+}
+
+.desks-search .form-input {
+  padding-left: 2rem;
+}
+
+/* ── Feature filter chips (sidebar) ────────────────────────────────────── */
+/* Override the global pill style: in the narrow sidebar column the chips
+   sit in a vertical list, so we give them a proper row appearance with
+   a visible background that contrasts against the card surface.            */
+.desks-feature-filter__chips .amenity-checkbox-label {
+  background: var(--color-surface-2);
+  border-color: var(--color-gray-300);
+  border-radius: var(--radius-md);    /* softer rectangle, not full pill */
+  padding: 0.4rem 0.75rem;
+  width: 100%;
+  justify-content: flex-start;
+  gap: 0.5rem;
+  color: var(--color-text);
+}
+
+.desks-feature-filter__chips .amenity-checkbox-label:hover {
+  background: var(--color-gray-100);
+  border-color: var(--color-primary);
+}
+
+/* Checked state — tinted brand background + brand border */
+.desks-feature-filter__chips .amenity-checkbox-label:has(input:checked) {
+  background: var(--color-primary-lighter);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  font-weight: 500;
+}
+
+/* Dark mode overrides */
+[data-theme="dark"] .desks-feature-filter__chips .amenity-checkbox-label {
+  background: var(--color-input-bg);   /* #334155 — clearly above #1e293b card */
+  border-color: var(--border-color);
+  color: var(--color-text);
+}
+
+[data-theme="dark"] .desks-feature-filter__chips .amenity-checkbox-label:hover {
+  background: var(--color-gray-200);
+  border-color: var(--color-primary);
+}
+
+[data-theme="dark"] .desks-feature-filter__chips .amenity-checkbox-label:has(input:checked) {
+  background: rgba(99, 102, 241, 0.18);
+  border-color: var(--color-primary);
+  color: var(--color-primary-hover);
+}
+
+/* System-preference dark mode mirrors the explicit dark overrides above */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .desks-feature-filter__chips .amenity-checkbox-label {
+    background: #334155;
+    border-color: #475569;
+    color: #f1f5f9;
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .desks-feature-filter__chips .amenity-checkbox-label:hover {
+    background: #475569;
+    border-color: #6366f1;
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .desks-feature-filter__chips .amenity-checkbox-label:has(input:checked) {
+    background: rgba(99, 102, 241, 0.18);
+    border-color: #6366f1;
+    color: #818cf8;
+  }
+
+  /* Amenity checkbox checked state */
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .amenity-checkbox-label {
+    background: #334155;
+    border-color: #475569;
+    color: #f1f5f9;
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .amenity-checkbox-label:hover {
+    background: #475569;
+    border-color: #6366f1;
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .amenity-checkbox-label:has(input:checked) {
+    background: rgba(99, 102, 241, 0.18);
+    border-color: #6366f1;
+    color: #818cf8;
+  }
+
+  /* Room finder badge + status — mirrors [data-theme="dark"] overrides */
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .finder-active-badge {
+    background: rgba(16, 185, 129, 0.15);
+    color: #6ee7b7;
+  }
+
+  :root:not([data-theme="light"]):not([data-theme="dark"]) .finder-status {
+    background: rgba(16, 185, 129, 0.1);
+    border-color: rgba(16, 185, 129, 0.25);
+    color: #94a3b8;
+  }
+}
+
+/* ── Pagination ─────────────────────────────────────────────────────────── */
+.desks-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  margin-top: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.desks-pagination__btn {
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  font-size: 1.1rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.desks-pagination__page {
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0 0.375rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--color-text);
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.desks-pagination__page:hover:not(.desks-pagination__page--active) {
+  background: var(--color-gray-100, #f3f4f6);
+}
+
+.desks-pagination__page--active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+  font-weight: 600;
+  cursor: default;
+}
+
+[data-theme="dark"] .desks-pagination__page:hover:not(.desks-pagination__page--active) {
+  background: var(--color-gray-200);
+}
+
+/* ── End Desks page layout ──────────────────────────────────────────────── */

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -308,6 +308,7 @@ export interface Desk {
   description: string | null;
   floor: string | null;
   isActive: boolean;
+  features?: string[];
   createdAt?: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
- Add DeskDatePicker component with single/range/multi-day modes, range hover preview, booked-date dots, and quota pill
- Add DatePicker component (custom calendar popup via React portal to escape overflow:hidden ancestors)
- Desk page: sidebar layout (calendar + quota card + search + feature filter on left, desk grid on right), pagination (9 per page), search
- Rooms page: custom DatePicker in finder form, search bar, pagination
- Quota card on desk page with progress bar and colour-coded states; hidden when quota is unlimited
- Fix desk quota scoping bug: AdminDesksPage always passed parkId='default' for super admins — now reads the selected park from localStorage so quota settings are correctly scoped per park
- Add desk features (tags) with migration 024 and admin UI
- Theme amenity checkboxes and finder form inputs with CSS variables for correct light/dark mode rendering