### PR TITLE
feat: add hot desk booking step to onboarding tour

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -44,7 +44,8 @@ export function Layout({ children }: LayoutProps) {
 
   // Guided tour
   const [runTour, setRunTour] = useState(false);
-  const tourSteps = getStepsForRole(user?.role ?? 'user');
+  const deskBookingEnabled = !!(user?.deskBookingEnabled || isAdmin || isParkAdmin || isSuperAdmin);
+  const tourSteps = getStepsForRole(user?.role ?? 'user', { deskBookingEnabled });
 
   // Sync the initial selectedParkId to localStorage before any child useEffect fires.
   // useLayoutEffect runs synchronously after DOM commit but before child useEffects,

--- a/frontend/src/tour/tourSteps.ts
+++ b/frontend/src/tour/tourSteps.ts
@@ -16,120 +16,144 @@ const step = (target: string, title: string, content: string, placement: Step['p
   disableBeacon: true,
 });
 
-export const tourStepsByRole: Record<string, Step[]> = {
+// ── Desk steps (inserted conditionally) ──────────────────────────────────────
 
-  // ──────────────────────────────────────────────────────────────
-  // Super Admin — sees everything
-  // ──────────────────────────────────────────────────────────────
-  super_admin: [
-    welcome,
-    step('park-select', 'Site Selector',
-      'Switch between parks (sites) here. As Super Admin you can manage all sites from one account. The data shown on every page reflects the selected site.'),
-    step('nav-calendar', 'Calendar',
-      'The visual weekly calendar shows every room\'s availability side-by-side. Click any open slot to create a booking. Past bookings remain visible for the full current week.'),
-    step('nav-rooms', 'Rooms',
-      'Browse the full list of meeting rooms. Filter by capacity and amenities to find the right space, then click a room to see its schedule and book directly.'),
-    step('nav-my-bookings', 'My Bookings',
-      'A list of all your own upcoming and past bookings. Cancel meetings, view attendee details, or check the room assigned to each booking.'),
-    step('nav-users', 'Users',
-      'Invite new users by email and assign them a role. View and edit existing accounts, reset two-factor authentication, and resend pending invite links.'),
-    step('nav-admin-rooms', 'Manage Rooms',
-      'Create and configure meeting rooms — set capacity, floor, amenities, per-room opening/closing hours, company access restrictions, and IoT display booking durations.'),
-    step('nav-admin-devices', 'Devices',
-      'Manage ESP32 room display devices. Monitor online status and last-seen timestamps, push over-the-air firmware updates, and regenerate device security tokens.'),
-    step('nav-admin-companies', 'Companies',
-      'Create and manage the companies (tenants) that share your site. Set company-level two-factor authentication policy and assign users to the correct company.'),
-    step('nav-admin-statistics', 'Statistics',
-      'Analytics for your site: room utilization percentages, peak booking hours, daily booking trends, amenity popularity, and top-booker rankings. Filter by custom date ranges.'),
-    step('nav-admin-settings', 'Settings',
-      'System-wide configuration: default booking hours, timezone, time format, two-factor authentication enforcement policy, and the system-wide announcement banner.'),
-    step('nav-admin-parks', 'Parks',
-      'Create and manage sites. Upload per-site logos, configure the visitor reception email and custom guest fields, and control whether iCal calendar feeds are enabled for a site.'),
-    step('user-menu', 'Account Menu',
-      'Click here to open your account menu. Access personal settings (two-factor authentication, calendar feed subscriptions, password), or log out.', 'auto'),
-  ],
+const deskUserStep = step('nav-desks', 'Hot Desks',
+  'Book a hot desk for a single day, a date range, or pick multiple individual days. Filter by features like standing desk or dual monitor, and track your monthly quota.');
 
-  // ──────────────────────────────────────────────────────────────
-  // Park Admin — sees Navigation + Management (Users) + Administration
-  // ──────────────────────────────────────────────────────────────
-  park_admin: [
-    welcome,
-    step('nav-calendar', 'Calendar',
-      'The visual weekly calendar shows every room\'s availability side-by-side. Click any open slot to create a booking. You can also view and manage any booking on behalf of users.'),
-    step('nav-rooms', 'Rooms',
-      'Browse all meeting rooms in your site. Filter by capacity and amenities, view room details and current availability.'),
-    step('nav-my-bookings', 'My Bookings',
-      'A list of all your own upcoming and past bookings. Cancel meetings, view attendee details, or check the room assigned to each booking.'),
-    step('nav-users', 'Users',
-      'Invite new users by email and assign them a role within your site. Edit accounts, reset two-factor authentication, and resend pending invite links.'),
-    step('nav-admin-rooms', 'Manage Rooms',
-      'Create and configure meeting rooms — set capacity, floor, amenities, per-room opening/closing hours, company access restrictions, quick-booking durations, and optional email-based booking (iMIP).'),
-    step('nav-admin-devices', 'Devices',
-      'Manage ESP32 room display devices mounted outside meeting rooms. Monitor status, push over-the-air firmware updates to individual devices or all at once, and regenerate access tokens.'),
-    step('nav-admin-companies', 'Companies',
-      'Create and manage the companies (tenants) that share your site. Set per-company two-factor authentication policy and control which users belong to which company.'),
-    step('nav-admin-statistics', 'Statistics',
-      'Analytics for your site: room utilization percentages, hourly and daily booking trends, peak hours, amenity popularity, and top bookers. Useful for optimizing your space.'),
-    step('nav-admin-settings', 'Settings',
-      'Configure default booking hours, timezone, time format, and two-factor authentication enforcement policy for your site.'),
-    step('user-menu', 'Account Menu',
-      'Click here to open your account menu. Access personal settings (two-factor authentication, calendar feed subscriptions, password), or log out.', 'auto'),
-  ],
+const deskAdminStep = step('nav-admin-desks', 'Manage Desks',
+  'Create and manage hot desks, set monthly booking quotas per user or per company, control which companies have access, and set individual quota overrides.');
 
-  // ──────────────────────────────────────────────────────────────
-  // Company Admin — sees Navigation + Management (Users, LDAP, SSO)
-  // ──────────────────────────────────────────────────────────────
-  company_admin: [
-    welcome,
-    step('nav-calendar', 'Calendar',
-      'The visual weekly calendar shows every available room side-by-side. Click any open slot to book a room for your team. The system prevents double-bookings automatically.'),
-    step('nav-rooms', 'Rooms',
-      'Browse available meeting rooms. Filter by capacity and amenities to find the right space, then book directly from the room detail view.'),
-    step('nav-my-bookings', 'My Bookings',
-      'A list of all your own upcoming and past bookings. Cancel meetings, view attendee details, or check the status of any booking.'),
-    step('nav-users', 'Users',
-      'Invite team members by email and assign them a role (User, Company Admin, or Receptionist). Edit existing accounts and resend invite links for pending users.'),
-    step('nav-ldap', 'LDAP Settings',
-      'Connect your company\'s LDAP directory to automatically sync users and map LDAP groups to application roles. Configure sync intervals and run manual syncs from here.'),
-    step('nav-sso', 'SSO Settings',
-      'Enable Single Sign-On so your team logs in with their existing corporate credentials. Supports OpenID Connect (OIDC) and SAML 2.0 — compatible with Keycloak, Azure AD, Okta, ADFS, and more.'),
-    step('user-menu', 'Account Menu',
-      'Click here to open your account menu. Access personal settings (two-factor authentication, calendar feed subscriptions, password), or log out.', 'auto'),
-  ],
+// ─────────────────────────────────────────────────────────────────────────────
 
-  // ──────────────────────────────────────────────────────────────
-  // Regular User — sees Navigation only
-  // ──────────────────────────────────────────────────────────────
-  user: [
-    welcome,
-    step('nav-calendar', 'Book a Room',
-      'The weekly calendar shows all rooms side-by-side. Green slots are free, red slots are booked. Click any open slot to create a booking — conflicts are prevented automatically.'),
-    step('nav-rooms', 'Browse Rooms',
-      'Filter rooms by capacity and amenities to find the right space for your meeting. Click a room to see its full schedule and book directly from there.'),
-    step('nav-my-bookings', 'My Bookings',
-      'All your upcoming and past bookings in one place. Cancel a meeting, see who else is attending, or check which room is assigned.'),
-    step('user-menu', 'Account Settings',
-      'Click here to access your personal account settings — set up two-factor authentication, generate calendar feed subscription URLs, change your password, or log out.', 'top'),
-  ],
+export function getStepsForRole(
+  role: string,
+  options: { deskBookingEnabled?: boolean } = {},
+): Step[] {
+  const deskEnabled = options.deskBookingEnabled ?? false;
 
-  // ──────────────────────────────────────────────────────────────
-  // Receptionist — sees Navigation + Reception
-  // ──────────────────────────────────────────────────────────────
-  receptionist: [
-    welcome,
-    step('nav-calendar', 'Calendar',
-      'The weekly calendar shows all room bookings. Use it to see which meetings are happening now and which rooms are available.'),
-    step('nav-rooms', 'Rooms',
-      'Browse all meeting rooms, view their amenities and current availability.'),
-    step('nav-my-bookings', 'My Bookings',
-      'A list of all your own bookings. Cancel meetings or review details from here.'),
-    step('nav-reception', 'Guest Management',
-      'Your main dashboard as a receptionist. See every expected visitor for today, check guests in when they arrive, and mark them out when they leave. Overstay alerts highlight guests still on-site past their meeting\'s end time.'),
-    step('user-menu', 'Account Settings',
-      'Click here to access your personal account settings — two-factor authentication, calendar feed subscriptions, or log out.', 'top'),
-  ],
-};
+  switch (role) {
 
-export function getStepsForRole(role: string): Step[] {
-  return tourStepsByRole[role] ?? tourStepsByRole['user'];
+    // ──────────────────────────────────────────────────────────────
+    // Super Admin — sees everything; desks always shown
+    // ──────────────────────────────────────────────────────────────
+    case 'super_admin': return [
+      welcome,
+      step('park-select', 'Site Selector',
+        'Switch between parks (sites) here. As Super Admin you can manage all sites from one account. The data shown on every page reflects the selected site.'),
+      step('nav-calendar', 'Calendar',
+        'The visual weekly calendar shows every room\'s availability side-by-side. Click any open slot to create a booking. Past bookings remain visible for the full current week.'),
+      step('nav-rooms', 'Rooms',
+        'Browse the full list of meeting rooms. Filter by capacity and amenities to find the right space, then click a room to see its schedule and book directly.'),
+      deskUserStep,
+      step('nav-my-bookings', 'My Bookings',
+        'A list of all your own upcoming and past bookings. Cancel meetings, view attendee details, or check the room assigned to each booking.'),
+      step('nav-users', 'Users',
+        'Invite new users by email and assign them a role. View and edit existing accounts, reset two-factor authentication, and resend pending invite links.'),
+      step('nav-admin-rooms', 'Manage Rooms',
+        'Create and configure meeting rooms — set capacity, floor, amenities, per-room opening/closing hours, company access restrictions, and IoT display booking durations.'),
+      deskAdminStep,
+      step('nav-admin-devices', 'Devices',
+        'Manage ESP32 room display devices. Monitor online status and last-seen timestamps, push over-the-air firmware updates, and regenerate device security tokens.'),
+      step('nav-admin-companies', 'Companies',
+        'Create and manage the companies (tenants) that share your site. Set company-level two-factor authentication policy and assign users to the correct company.'),
+      step('nav-admin-statistics', 'Statistics',
+        'Analytics for your site: room utilization percentages, peak booking hours, daily booking trends, amenity popularity, and top-booker rankings. Filter by custom date ranges.'),
+      step('nav-admin-settings', 'Settings',
+        'System-wide configuration: default booking hours, timezone, time format, two-factor authentication enforcement policy, and the system-wide announcement banner.'),
+      step('nav-admin-parks', 'Parks',
+        'Create and manage sites. Upload per-site logos, configure the visitor reception email and custom guest fields, and control whether iCal calendar feeds are enabled for a site.'),
+      step('user-menu', 'Account Menu',
+        'Click here to open your account menu. Access personal settings (two-factor authentication, calendar feed subscriptions, password), or log out.', 'auto'),
+    ];
+
+    // ──────────────────────────────────────────────────────────────
+    // Park Admin — sees Navigation + Management (Users) + Administration
+    // desks always shown
+    // ──────────────────────────────────────────────────────────────
+    case 'park_admin': return [
+      welcome,
+      step('nav-calendar', 'Calendar',
+        'The visual weekly calendar shows every room\'s availability side-by-side. Click any open slot to create a booking. You can also view and manage any booking on behalf of users.'),
+      step('nav-rooms', 'Rooms',
+        'Browse all meeting rooms in your site. Filter by capacity and amenities, view room details and current availability.'),
+      deskUserStep,
+      step('nav-my-bookings', 'My Bookings',
+        'A list of all your own upcoming and past bookings. Cancel meetings, view attendee details, or check the room assigned to each booking.'),
+      step('nav-users', 'Users',
+        'Invite new users by email and assign them a role within your site. Edit accounts, reset two-factor authentication, and resend pending invite links.'),
+      step('nav-admin-rooms', 'Manage Rooms',
+        'Create and configure meeting rooms — set capacity, floor, amenities, per-room opening/closing hours, company access restrictions, quick-booking durations, and optional email-based booking (iMIP).'),
+      deskAdminStep,
+      step('nav-admin-devices', 'Devices',
+        'Manage ESP32 room display devices mounted outside meeting rooms. Monitor status, push over-the-air firmware updates to individual devices or all at once, and regenerate access tokens.'),
+      step('nav-admin-companies', 'Companies',
+        'Create and manage the companies (tenants) that share your site. Set per-company two-factor authentication policy and control which users belong to which company.'),
+      step('nav-admin-statistics', 'Statistics',
+        'Analytics for your site: room utilization percentages, hourly and daily booking trends, peak hours, amenity popularity, and top bookers. Useful for optimizing your space.'),
+      step('nav-admin-settings', 'Settings',
+        'Configure default booking hours, timezone, time format, and two-factor authentication enforcement policy for your site.'),
+      step('user-menu', 'Account Menu',
+        'Click here to open your account menu. Access personal settings (two-factor authentication, calendar feed subscriptions, password), or log out.', 'auto'),
+    ];
+
+    // ──────────────────────────────────────────────────────────────
+    // Company Admin — sees Navigation + Management (Users, LDAP, SSO)
+    // desks shown if company has desk booking enabled
+    // ──────────────────────────────────────────────────────────────
+    case 'company_admin': return [
+      welcome,
+      step('nav-calendar', 'Calendar',
+        'The visual weekly calendar shows every available room side-by-side. Click any open slot to book a room for your team. The system prevents double-bookings automatically.'),
+      step('nav-rooms', 'Rooms',
+        'Browse available meeting rooms. Filter by capacity and amenities to find the right space, then book directly from the room detail view.'),
+      ...(deskEnabled ? [deskUserStep] : []),
+      step('nav-my-bookings', 'My Bookings',
+        'A list of all your own upcoming and past bookings. Cancel meetings, view attendee details, or check the status of any booking.'),
+      step('nav-users', 'Users',
+        'Invite team members by email and assign them a role (User, Company Admin, or Receptionist). Edit existing accounts and resend invite links for pending users.'),
+      step('nav-ldap', 'LDAP Settings',
+        'Connect your company\'s LDAP directory to automatically sync users and map LDAP groups to application roles. Configure sync intervals and run manual syncs from here.'),
+      step('nav-sso', 'SSO Settings',
+        'Enable Single Sign-On so your team logs in with their existing corporate credentials. Supports OpenID Connect (OIDC) and SAML 2.0 — compatible with Keycloak, Azure AD, Okta, ADFS, and more.'),
+      step('user-menu', 'Account Menu',
+        'Click here to open your account menu. Access personal settings (two-factor authentication, calendar feed subscriptions, password), or log out.', 'auto'),
+    ];
+
+    // ──────────────────────────────────────────────────────────────
+    // Receptionist — sees Navigation + Reception
+    // desks shown if company has desk booking enabled
+    // ──────────────────────────────────────────────────────────────
+    case 'receptionist': return [
+      welcome,
+      step('nav-calendar', 'Calendar',
+        'The weekly calendar shows all room bookings. Use it to see which meetings are happening now and which rooms are available.'),
+      step('nav-rooms', 'Rooms',
+        'Browse all meeting rooms, view their amenities and current availability.'),
+      ...(deskEnabled ? [deskUserStep] : []),
+      step('nav-my-bookings', 'My Bookings',
+        'A list of all your own bookings. Cancel meetings or review details from here.'),
+      step('nav-reception', 'Guest Management',
+        'Your main dashboard as a receptionist. See every expected visitor for today, check guests in when they arrive, and mark them out when they leave. Overstay alerts highlight guests still on-site past their meeting\'s end time.'),
+      step('user-menu', 'Account Settings',
+        'Click here to access your personal account settings — two-factor authentication, calendar feed subscriptions, or log out.', 'top'),
+    ];
+
+    // ──────────────────────────────────────────────────────────────
+    // Regular User — sees Navigation only
+    // desks shown if company has desk booking enabled
+    // ──────────────────────────────────────────────────────────────
+    default: return [
+      welcome,
+      step('nav-calendar', 'Book a Room',
+        'The weekly calendar shows all rooms side-by-side. Green slots are free, red slots are booked. Click any open slot to create a booking — conflicts are prevented automatically.'),
+      step('nav-rooms', 'Browse Rooms',
+        'Filter rooms by capacity and amenities to find the right space for your meeting. Click a room to see its full schedule and book directly from there.'),
+      ...(deskEnabled ? [deskUserStep] : []),
+      step('nav-my-bookings', 'My Bookings',
+        'All your upcoming and past bookings in one place. Cancel a meeting, see who else is attending, or check which room is assigned.'),
+      step('user-menu', 'Account Settings',
+        'Click here to access your personal account settings — set up two-factor authentication, generate calendar feed subscription URLs, change your password, or log out.', 'top'),
+    ];
+  }
 }


### PR DESCRIPTION
Insert a Hot Desks step (nav-desks) after the Rooms step for all roles. For regular users, company admins, and receptionists the step only appears when desk booking is enabled for their company. For park admins and super admins (who always have access) both the user-facing Hot Desks step and the admin Manage Desks step (nav-admin-desks) are always shown, inserted immediately after their respective sibling steps.

Converted the static tourStepsByRole record to a getStepsForRole function that accepts a deskBookingEnabled option, keeping the step lists explicit and easy to maintain. Layout derives deskBookingEnabled from the same condition used to render the nav item.