### PR TITLE
fix: improve past time slot visibility on calendar

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1773,7 +1773,7 @@ body {
 }
 
 .time-slot.past {
-  background: #f3f4f6;
+  background: #d1d5db;
   cursor: not-allowed;
 }
 
@@ -1937,8 +1937,8 @@ body {
 }
 
 .legend-color.past {
-  background: #f3f4f6;
-  border-color: #d1d5db;
+  background: #d1d5db;
+  border-color: #9ca3af;
 }
 
 .legend-color.unavailable {
@@ -5130,7 +5130,7 @@ body {
   border-radius: var(--radius-sm);
 }
 
-.time-slot.today-column {
+.time-slot.today-column:not(.past) {
   background: rgba(79, 70, 229, 0.03);
 }
 


### PR DESCRIPTION
Increase past slot background from #f3f4f6 (gray-100, near-white) to #d1d5db (gray-300) so the disabled state is clearly visible on older or lower-contrast screens. Update the legend swatch to match.

Also fix a CSS specificity bug where .time-slot.today-column (declared later in the stylesheet) was overriding .time-slot.past with equal specificity, causing today's past slots to show as transparent instead of gray. Added :not(.past) guard to the today-column rule.