### PR TITLE
feat: hot desk calendar settings, closed days, and booking constraints

### DIFF
--- a/backend/src/migrations/025_park_blocked_weekdays.ts
+++ b/backend/src/migrations/025_park_blocked_weekdays.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn('parks', 'blocked_weekdays'))) {
+    await knex.schema.alterTable('parks', (table) => {
+      // JSON array of ints 0-6 (0=Sunday … 6=Saturday). Default empty = no blocked days.
+      table.text('blocked_weekdays').notNullable().defaultTo('[]');
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // SQLite doesn't support DROP COLUMN — intentionally left as no-op
+}

--- a/backend/src/migrations/026_park_week_start_day.ts
+++ b/backend/src/migrations/026_park_week_start_day.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasColumn('parks', 'week_start_day'))) {
+    await knex.schema.alterTable('parks', (table) => {
+      // 0=Sunday, 1=Monday (default), 2=Tuesday … 6=Saturday
+      table.integer('week_start_day').notNullable().defaultTo(1);
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // SQLite doesn't support DROP COLUMN — intentionally left as no-op
+}

--- a/backend/src/models/park.model.ts
+++ b/backend/src/models/park.model.ts
@@ -47,7 +47,7 @@ export class ParkModel {
     return rows.map((row: any) => this.mapRowToPark(row));
   }
 
-  static async update(id: string, data: Partial<CreateParkRequest> & { isActive?: boolean; twofaEnforcement?: TwoFaLevelEnforcement; calendarFeedEnabled?: boolean; deskQuotaType?: DeskQuotaType | null; monthlyDeskQuota?: number | null }): Promise<Park | null> {
+  static async update(id: string, data: Partial<CreateParkRequest> & { isActive?: boolean; twofaEnforcement?: TwoFaLevelEnforcement; calendarFeedEnabled?: boolean; deskQuotaType?: DeskQuotaType | null; monthlyDeskQuota?: number | null; blockedWeekdays?: number[]; weekStartDay?: number }): Promise<Park | null> {
     const existing = await this.findById(id);
     if (!existing) return null;
 
@@ -75,6 +75,12 @@ export class ParkModel {
     }
     if (data.monthlyDeskQuota !== undefined) {
       updateObj.monthly_desk_quota = data.monthlyDeskQuota ?? null;
+    }
+    if (data.blockedWeekdays !== undefined) {
+      updateObj.blocked_weekdays = JSON.stringify(data.blockedWeekdays);
+    }
+    if (data.weekStartDay !== undefined) {
+      updateObj.week_start_day = data.weekStartDay;
     }
 
     await db('parks').where('id', id).update(updateObj);
@@ -126,6 +132,8 @@ export class ParkModel {
       calendarFeedEnabled: row.calendar_feed_enabled !== undefined ? !!row.calendar_feed_enabled : true,
       deskQuotaType: (row.desk_quota_type as DeskQuotaType) || null,
       monthlyDeskQuota: row.monthly_desk_quota ? Number(row.monthly_desk_quota) : null,
+      blockedWeekdays: JSON.parse(row.blocked_weekdays || '[]'),
+      weekStartDay: row.week_start_day !== undefined ? Number(row.week_start_day) : 1,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };

--- a/backend/src/routes/desk-booking.routes.ts
+++ b/backend/src/routes/desk-booking.routes.ts
@@ -26,6 +26,12 @@ function todayDateString(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+function maxBookingDateString(): string {
+  const d = new Date();
+  d.setMonth(d.getMonth() + 3);
+  return d.toISOString().slice(0, 10);
+}
+
 // GET /api/desk-bookings — all confirmed bookings for user's park (startDate + endDate required)
 router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
   try {
@@ -111,7 +117,14 @@ router.get('/quota', authenticate, async (req: AuthRequest, res: Response) => {
 
     const park = await ParkModel.findById(parkId);
     if (!park || !park.monthlyDeskQuota || !park.deskQuotaType) {
-      res.json({ quotaType: null, monthlyQuota: null, usedThisMonth: 0, remainingThisMonth: null });
+      res.json({
+        quotaType: null,
+        monthlyQuota: null,
+        usedThisMonth: 0,
+        remainingThisMonth: null,
+        blockedWeekdays: park?.blockedWeekdays ?? [],
+        weekStartDay: park?.weekStartDay ?? 1,
+      });
       return;
     }
 
@@ -134,6 +147,8 @@ router.get('/quota', authenticate, async (req: AuthRequest, res: Response) => {
       monthlyQuota: effectiveQuota,
       usedThisMonth: used,
       remainingThisMonth: Math.max(0, effectiveQuota - used),
+      blockedWeekdays: park.blockedWeekdays,
+      weekStartDay: park.weekStartDay,
     });
   } catch (err) {
     console.error('Error checking desk quota:', err);
@@ -198,6 +213,10 @@ router.post('/', authenticate, deskBookingCreateLimiter, async (req: AuthRequest
       res.status(400).json({ error: 'Cannot book a desk in the past' });
       return;
     }
+    if (bookingDate > maxBookingDateString()) {
+      res.status(400).json({ error: 'Desk bookings cannot be made more than 3 months in advance' });
+      return;
+    }
 
     // Load desk
     const desk = await DeskModel.findById(deskId);
@@ -223,8 +242,17 @@ router.post('/', authenticate, deskBookingCreateLimiter, async (req: AuthRequest
       return;
     }
 
-    // Quota check (park-level)
+    // Blocked-weekday + quota checks (park-level)
     const park = await ParkModel.findById(desk.parkId);
+    if (park && park.blockedWeekdays.length > 0) {
+      // Parse date parts directly to avoid timezone shifting
+      const [y, m, d] = bookingDate.split('-').map(Number);
+      const weekday = new Date(y, m - 1, d).getDay(); // 0=Sun … 6=Sat
+      if (park.blockedWeekdays.includes(weekday)) {
+        res.status(400).json({ error: 'The park is closed on that day' });
+        return;
+      }
+    }
     if (park && park.monthlyDeskQuota && park.deskQuotaType) {
       const month = bookingDate.substring(0, 7); // 'YYYY-MM'
 

--- a/backend/src/routes/park.routes.ts
+++ b/backend/src/routes/park.routes.ts
@@ -499,6 +499,8 @@ router.get('/:id/desk-quota', authenticate, async (req: AuthRequest, res: Respon
     res.json({
       deskQuotaType: park.deskQuotaType,
       monthlyDeskQuota: park.monthlyDeskQuota,
+      blockedWeekdays: park.blockedWeekdays,
+      weekStartDay: park.weekStartDay,
       overrides,
     });
   } catch (err) {
@@ -514,7 +516,7 @@ router.put('/:id/desk-quota', authenticate, async (req: AuthRequest, res: Respon
       res.status(403).json({ error: 'Access denied' });
       return;
     }
-    const { deskQuotaType, monthlyDeskQuota } = req.body;
+    const { deskQuotaType, monthlyDeskQuota, blockedWeekdays, weekStartDay } = req.body;
 
     if (deskQuotaType !== null && deskQuotaType !== undefined &&
         !['per_user', 'per_company'].includes(deskQuotaType)) {
@@ -525,14 +527,34 @@ router.put('/:id/desk-quota', authenticate, async (req: AuthRequest, res: Respon
       res.status(400).json({ error: 'monthlyDeskQuota must be a positive integer when quota type is set' });
       return;
     }
+    if (blockedWeekdays !== undefined) {
+      if (!Array.isArray(blockedWeekdays) || blockedWeekdays.some((d: any) => !Number.isInteger(d) || d < 0 || d > 6)) {
+        res.status(400).json({ error: 'blockedWeekdays must be an array of integers 0–6' });
+        return;
+      }
+    }
+
+    if (weekStartDay !== undefined) {
+      if (!Number.isInteger(weekStartDay) || weekStartDay < 0 || weekStartDay > 6) {
+        res.status(400).json({ error: 'weekStartDay must be an integer 0–6' });
+        return;
+      }
+    }
 
     const updated = await ParkModel.update(req.params.id, {
       deskQuotaType: deskQuotaType as DeskQuotaType | null ?? null,
       monthlyDeskQuota: deskQuotaType ? monthlyDeskQuota : null,
+      ...(blockedWeekdays !== undefined && { blockedWeekdays }),
+      ...(weekStartDay !== undefined && { weekStartDay }),
     });
     if (!updated) { res.status(404).json({ error: 'Park not found' }); return; }
 
-    res.json({ deskQuotaType: updated.deskQuotaType, monthlyDeskQuota: updated.monthlyDeskQuota });
+    res.json({
+      deskQuotaType: updated.deskQuotaType,
+      monthlyDeskQuota: updated.monthlyDeskQuota,
+      blockedWeekdays: updated.blockedWeekdays,
+      weekStartDay: updated.weekStartDay,
+    });
   } catch (err) {
     console.error('Error updating park desk quota:', err);
     res.status(500).json({ error: 'Failed to update desk quota settings' });

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -28,6 +28,8 @@ export interface Park {
   calendarFeedEnabled: boolean;
   deskQuotaType: DeskQuotaType | null;
   monthlyDeskQuota: number | null;
+  blockedWeekdays: number[]; // 0=Sun … 6=Sat
+  weekStartDay: number;      // 0=Sun, 1=Mon (default) … 6=Sat
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/components/DeskDatePicker.tsx
+++ b/frontend/src/components/DeskDatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { DeskQuotaStatus } from '../types';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -14,6 +14,9 @@ interface DeskDatePickerProps {
   myBookedDates: string[];     // YYYY-MM-DD[] – user's confirmed bookings
   quota: DeskQuotaStatus | null;
   quotaNextMonth: DeskQuotaStatus | null;
+  blockedWeekdays?: number[];  // 0=Sun … 6=Sat — days the park is closed
+  weekStartDay?: number;       // 0=Sun, 1=Mon (default) … 6=Sat
+  onViewMonthChange?: (month: string) => void; // YYYY-MM, fired when user navigates months
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -32,22 +35,33 @@ function daysInMonth(year: number, month: number): number {
   return new Date(year, month + 1, 0).getDate();
 }
 
-/** Day-of-week (0 = Sun) for the 1st of the month. */
-function firstDayOfWeek(year: number, month: number): number {
-  return new Date(year, month, 1).getDay();
+/**
+ * Returns the 0-based column position of the 1st of the month given a week
+ * start day.  e.g. weekStart=1 (Mon) → Monday occupies column 0.
+ */
+function firstDayOfWeek(year: number, month: number, weekStart: number): number {
+  const raw = new Date(year, month, 1).getDay(); // 0=Sun … 6=Sat
+  return (raw - weekStart + 7) % 7;
 }
 
 const MONTH_NAMES = [
   'January', 'February', 'March', 'April', 'May', 'June',
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
-const DAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const ALL_DAY_LABELS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 
 /** Short human-readable label for a YYYY-MM-DD string. */
 function formatDateLabel(iso: string): string {
   const [year, month, day] = iso.split('-').map(Number);
   const d = new Date(year, month - 1, day);
   return d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
+}
+
+/** Returns the max bookable date as YYYY-MM-DD (3 months from today, same day). */
+function maxBookableDate(): string {
+  const d = new Date();
+  d.setMonth(d.getMonth() + 3);
+  return d.toISOString().slice(0, 10);
 }
 
 /** Number of calendar days between two ISO strings (inclusive). */
@@ -70,12 +84,22 @@ export function DeskDatePicker({
   myBookedDates,
   quota,
   quotaNextMonth,
+  blockedWeekdays = [],
+  weekStartDay = 1,
+  onViewMonthChange,
 }: DeskDatePickerProps) {
 
   // ── View month state ──────────────────────────────────────────────────────
   const initialISO = rangeStart || todayISO();
   const [viewYear, setViewYear]   = useState(() => parseInt(initialISO.slice(0, 4), 10));
   const [viewMonth, setViewMonth] = useState(() => parseInt(initialISO.slice(5, 7), 10) - 1);
+
+  // Notify parent whenever the displayed month changes (skip initial render)
+  const didMountRef = useRef(false);
+  useEffect(() => {
+    if (!didMountRef.current) { didMountRef.current = true; return; }
+    onViewMonthChange?.(`${viewYear}-${String(viewMonth + 1).padStart(2, '0')}`);
+  }, [viewYear, viewMonth]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Hover preview state (range mode only) ────────────────────────────────
   const [hoverDate, setHoverDate] = useState<string | null>(null);
@@ -148,7 +172,11 @@ export function DeskDatePicker({
   };
 
   // ── Cell classifier ───────────────────────────────────────────────────────
-  const today = todayISO();
+  const today   = todayISO();
+  const maxDate = maxBookableDate();
+
+  // Derived: YYYY-MM of the max bookable date — used to cap navigation
+  const maxViewMonth = maxDate.slice(0, 7);
 
   const visualEnd: string | null = (() => {
     if (dateMode === 'range' && rangeStart && !rangeEnd && hoverDate && hoverDate >= rangeStart) {
@@ -170,7 +198,9 @@ export function DeskDatePicker({
     isBooked: boolean;
     isHoverPreview: boolean;
   } {
-    const isPast  = iso < today;
+    const [y, mo, d] = iso.split('-').map(Number);
+    const weekday = new Date(y, mo - 1, d).getDay();
+    const isPast  = iso < today || iso > maxDate || blockedWeekdays.includes(weekday);
     const isToday = iso === today;
 
     // In multi mode each selected date is a "start" (gets the filled circle)
@@ -194,7 +224,8 @@ export function DeskDatePicker({
 
   // ── Calendar grid construction ────────────────────────────────────────────
   const totalDays = daysInMonth(viewYear, viewMonth);
-  const startPad  = firstDayOfWeek(viewYear, viewMonth);
+  const startPad  = firstDayOfWeek(viewYear, viewMonth, weekStartDay);
+  const DAY_LABELS = [...ALL_DAY_LABELS.slice(weekStartDay), ...ALL_DAY_LABELS.slice(0, weekStartDay)];
 
   // ── Selected date summary line ────────────────────────────────────────────
   const summaryLine: string | null = (() => {
@@ -286,6 +317,7 @@ export function DeskDatePicker({
           type="button"
           className="ddp__nav-btn"
           onClick={nextMonth}
+          disabled={`${viewYear}-${String(viewMonth + 1).padStart(2, '0')}` >= maxViewMonth}
           aria-label="Next month"
         >
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">

--- a/frontend/src/pages/AdminDesksPage.tsx
+++ b/frontend/src/pages/AdminDesksPage.tsx
@@ -52,6 +52,8 @@ export function AdminDesksPage() {
   const [parkQuota, setParkQuota] = useState<ParkDeskQuota | null>(null);
   const [quotaType, setQuotaType] = useState<DeskQuotaType | ''>('');
   const [monthlyLimit, setMonthlyLimit] = useState('');
+  const [blockedWeekdays, setBlockedWeekdays] = useState<number[]>([]);
+  const [weekStartDay, setWeekStartDay] = useState<number>(1);
   const [savingQuota, setSavingQuota] = useState(false);
   const [quotaError, setQuotaError] = useState('');
   const [quotaSuccess, setQuotaSuccess] = useState('');
@@ -88,6 +90,8 @@ export function AdminDesksPage() {
       setParkQuota(quotaData);
       setQuotaType(quotaData.deskQuotaType ?? '');
       setMonthlyLimit(quotaData.monthlyDeskQuota !== null ? String(quotaData.monthlyDeskQuota) : '');
+      setBlockedWeekdays(quotaData.blockedWeekdays ?? []);
+      setWeekStartDay(quotaData.weekStartDay ?? 1);
       setParkUsers(usersData.filter((u) => u.isActive));
       setCompanies(companiesData);
     } catch {
@@ -191,11 +195,13 @@ export function AdminDesksPage() {
 
     setSavingQuota(true);
     try {
-      await api.updateParkDeskQuota(parkId, type, limit);
+      await api.updateParkDeskQuota(parkId, type, limit, blockedWeekdays, weekStartDay);
       const updated = await api.getParkDeskQuota(parkId);
       setParkQuota(updated);
       setQuotaType(updated.deskQuotaType ?? '');
       setMonthlyLimit(updated.monthlyDeskQuota !== null ? String(updated.monthlyDeskQuota) : '');
+      setBlockedWeekdays(updated.blockedWeekdays ?? []);
+      setWeekStartDay(updated.weekStartDay ?? 1);
       setQuotaSuccess('Quota settings saved');
       setTimeout(() => setQuotaSuccess(''), 3000);
     } catch (err: any) {
@@ -421,6 +427,72 @@ export function AdminDesksPage() {
               </button>
             </div>
           </form>
+
+          {/* Calendar & closed days */}
+          <div style={{ marginTop: '2rem', borderTop: '1px solid #e5e7eb', paddingTop: '1.5rem' }}>
+            <h2 style={{ fontSize: '1rem', fontWeight: 600, marginBottom: '0.2rem' }}>Calendar Settings</h2>
+            <p style={{ color: '#6b7280', fontSize: '0.875rem', marginBottom: '1rem' }}>
+              Configure how the booking calendar is displayed and which days are unavailable.
+            </p>
+
+            <div className="form-group" style={{ maxWidth: '220px', marginBottom: '1.5rem' }}>
+              <label htmlFor="weekStartDay">Week starts on</label>
+              <select
+                id="weekStartDay"
+                value={weekStartDay}
+                onChange={(e) => setWeekStartDay(Number(e.target.value))}
+              >
+                <option value={0}>Sunday</option>
+                <option value={1}>Monday</option>
+                <option value={2}>Tuesday</option>
+                <option value={3}>Wednesday</option>
+                <option value={4}>Thursday</option>
+                <option value={5}>Friday</option>
+                <option value={6}>Saturday</option>
+              </select>
+            </div>
+
+            <p style={{ fontWeight: 500, fontSize: '0.875rem', marginBottom: '0.5rem' }}>Closed days</p>
+            <p style={{ color: '#6b7280', fontSize: '0.875rem', marginBottom: '0.75rem' }}>
+              Users will not be able to book desks on the selected days of the week.
+            </p>
+            <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+              {(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const).map((label, idx) => {
+                const checked = blockedWeekdays.includes(idx);
+                return (
+                  <label
+                    key={idx}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: '0.35rem',
+                      padding: '0.35rem 0.75rem',
+                      borderRadius: '6px',
+                      border: `1px solid ${checked ? '#6366f1' : '#d1d5db'}`,
+                      background: checked ? '#eef2ff' : 'transparent',
+                      cursor: 'pointer',
+                      fontSize: '0.875rem',
+                      fontWeight: checked ? 600 : 400,
+                      userSelect: 'none',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() =>
+                        setBlockedWeekdays(prev =>
+                          prev.includes(idx) ? prev.filter(d => d !== idx) : [...prev, idx].sort((a, b) => a - b)
+                        )
+                      }
+                      style={{ display: 'none' }}
+                    />
+                    {label}
+                  </label>
+                );
+              })}
+            </div>
+            <p style={{ color: '#9ca3af', fontSize: '0.8rem', marginTop: '0.5rem' }}>
+              Click "Save Quota" above to apply closed-day changes.
+            </p>
+          </div>
 
           {/* User exceptions — only shown when quota type is per_user */}
           {parkQuota?.deskQuotaType === 'per_user' && (

--- a/frontend/src/pages/DesksPage.tsx
+++ b/frontend/src/pages/DesksPage.tsx
@@ -25,6 +25,8 @@ export function DesksPage() {
   const [myBookings, setMyBookings] = useState<DeskBooking[]>([]);
   const [quota, setQuota] = useState<DeskQuotaStatus | null>(null);
   const [quotaNextMonth, setQuotaNextMonth] = useState<DeskQuotaStatus | null>(null);
+  const [blockedWeekdays, setBlockedWeekdays] = useState<number[]>([]);
+  const [weekStartDay, setWeekStartDay] = useState<number>(1);
   const [loading, setLoading] = useState(true);
   const [accessDenied, setAccessDenied] = useState(false);
   const [bookingDeskId, setBookingDeskId] = useState<string | null>(null);
@@ -41,10 +43,13 @@ export function DesksPage() {
 
   // ─── Derived values ───────────────────────────────────────────────────────
 
-  const currentMonth = rangeStart.slice(0, 7);
+  // Track the month the user is currently viewing in the calendar (independent
+  // of rangeStart so navigating months updates the quota display immediately).
+  const [calendarViewMonth, setCalendarViewMonth] = useState<string>(() => todayISO().slice(0, 7));
+  const currentMonth = calendarViewMonth;
 
   const nextMonthKey = (() => {
-    const d = new Date(rangeStart + 'T00:00:00');
+    const d = new Date(calendarViewMonth + '-02');
     d.setMonth(d.getMonth() + 1);
     return d.toISOString().slice(0, 7);
   })();
@@ -57,15 +62,25 @@ export function DesksPage() {
     const cursor = new Date(rangeStart + 'T00:00:00');
     const end = new Date(rangeEnd + 'T00:00:00');
     while (cursor <= end) {
-      dates.push(cursor.toISOString().slice(0, 10));
+      const y = cursor.getFullYear();
+      const mo = String(cursor.getMonth() + 1).padStart(2, '0');
+      const d = String(cursor.getDate()).padStart(2, '0');
+      dates.push(`${y}-${mo}-${d}`);
       cursor.setDate(cursor.getDate() + 1);
     }
     return dates;
   }, [dateMode, rangeStart, rangeEnd, multiDates]);
 
-  const totalSelectedDays = selectedDates.length;
-  const selectedDaysThisMonth = selectedDates.filter(d => d.slice(0, 7) === currentMonth).length;
-  const selectedDaysNextMonth = selectedDates.filter(d => d.slice(0, 7) === nextMonthKey).length;
+  // In range/multi mode, skip closed days — they can't be booked and shouldn't
+  // inflate quota counts or the "Book N Days" button label.
+  const bookableDates = selectedDates.filter(date => {
+    const [y, m, d] = date.split('-').map(Number);
+    return !blockedWeekdays.includes(new Date(y, m - 1, d).getDay());
+  });
+
+  const totalSelectedDays = bookableDates.length;
+  const selectedDaysThisMonth = bookableDates.filter(d => d.slice(0, 7) === currentMonth).length;
+  const selectedDaysNextMonth = bookableDates.filter(d => d.slice(0, 7) === nextMonthKey).length;
 
   const effectiveEnd = dateMode === 'range' && rangeEnd && rangeEnd >= rangeStart ? rangeEnd : rangeStart;
 
@@ -123,6 +138,9 @@ export function DesksPage() {
     try {
       const status = await api.getDeskQuotaStatus(month);
       setQuota(status);
+      // blockedWeekdays is park-level (same regardless of month) — keep in sync
+      setBlockedWeekdays(status.blockedWeekdays ?? []);
+      setWeekStartDay(status.weekStartDay ?? 1);
     } catch {
       setQuota(null);
     }
@@ -179,6 +197,13 @@ export function DesksPage() {
     }
   }, [rangeStart, rangeEnd, dateMode, multiDates]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Reload quota whenever the calendar view month changes (user navigates months).
+  useEffect(() => {
+    if (!loading) {
+      loadQuota(calendarViewMonth).catch(console.error);
+    }
+  }, [calendarViewMonth]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // ─── Event handlers ───────────────────────────────────────────────────────
 
   const handleBook = async (desk: Desk) => {
@@ -186,7 +211,7 @@ export function DesksPage() {
     setBookingErrors((prev) => ({ ...prev, [desk.id]: '' }));
     setBookingResult(null);
 
-    const datesToBook = selectedDates.length > 0 ? selectedDates : [rangeStart];
+    const datesToBook = bookableDates.length > 0 ? bookableDates : [rangeStart];
     const succeeded: string[] = [];
     const failed: Array<{ date: string; error: string }> = [];
 
@@ -211,6 +236,16 @@ export function DesksPage() {
       loadQuota(currentMonth),
       ...(selectedDaysNextMonth > 0 ? [loadQuotaNextMonth(nextMonthKey)] : []),
     ]);
+
+    // Clear selection after booking so old picks don't carry over to the next booking
+    if (succeeded.length > 0) {
+      if (dateMode === 'multi') {
+        setMultiDates([]);
+      } else if (dateMode === 'range') {
+        setRangeEnd('');
+      }
+    }
+
     setBookingDeskId(null);
   };
 
@@ -299,6 +334,9 @@ export function DesksPage() {
             myBookedDates={myBookings.filter(b => b.status === 'confirmed').map(b => b.bookingDate)}
             quota={quota}
             quotaNextMonth={quotaNextMonth}
+            blockedWeekdays={blockedWeekdays}
+            weekStartDay={weekStartDay}
+            onViewMonthChange={(month) => setCalendarViewMonth(month)}
           />
 
           {/* Desk search */}
@@ -317,7 +355,9 @@ export function DesksPage() {
           {quota && quota.monthlyQuota !== null && quota.remainingThisMonth !== null && (
             <div className="desks-quota-card">
               <div className="desks-quota-card__header">
-                <span className="desks-quota-card__title">This Month's Quota</span>
+                <span className="desks-quota-card__title">
+                  {new Date(currentMonth + '-02').toLocaleString('default', { month: 'long', year: 'numeric' })} Quota
+                </span>
                 {quota.quotaType === 'per_company' && (
                   <span className="desks-quota-card__badge">Shared</span>
                 )}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1065,10 +1065,15 @@ class ApiService {
     return this.request<ParkDeskQuota>(`/parks/${parkId}/desk-quota`);
   }
 
-  async updateParkDeskQuota(parkId: string, deskQuotaType: string | null, monthlyDeskQuota: number | null): Promise<void> {
+  async updateParkDeskQuota(parkId: string, deskQuotaType: string | null, monthlyDeskQuota: number | null, blockedWeekdays?: number[], weekStartDay?: number): Promise<void> {
     return this.request<void>(`/parks/${parkId}/desk-quota`, {
       method: 'PUT',
-      body: JSON.stringify({ deskQuotaType, monthlyDeskQuota }),
+      body: JSON.stringify({
+        deskQuotaType,
+        monthlyDeskQuota,
+        ...(blockedWeekdays !== undefined && { blockedWeekdays }),
+        ...(weekStartDay !== undefined && { weekStartDay }),
+      }),
     });
   }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -329,6 +329,8 @@ export interface DeskQuotaStatus {
   monthlyQuota: number | null;
   usedThisMonth: number;
   remainingThisMonth: number | null; // null = unlimited
+  blockedWeekdays: number[]; // 0=Sun … 6=Sat
+  weekStartDay: number;      // 0=Sun, 1=Mon …
 }
 
 export interface UserDeskQuota {
@@ -344,5 +346,7 @@ export interface UserDeskQuota {
 export interface ParkDeskQuota {
   deskQuotaType: DeskQuotaType | null;
   monthlyDeskQuota: number | null;
+  blockedWeekdays: number[]; // 0=Sun … 6=Sat
+  weekStartDay: number;      // 0=Sun, 1=Mon …
   overrides: UserDeskQuota[];
 }


### PR DESCRIPTION
## Summary

- **Closed days**: Admins can block specific weekdays (e.g. weekends) so users cannot book desks on those days — enforced in both the UI calendar and the API
- **Week start day**: Admins can configure which day the booking calendar week starts on (Sun–Sat), defaulting to Monday
- **3-month booking horizon**: Desk bookings are now capped at 3 months in advance — enforced server-side and reflected in the calendar's forward-navigation limit
- **Quota display by view month**: The quota card now shows the month the user is viewing in the calendar, not just "This Month", and reloads when navigating

## Changes

**Migrations**
- `025_park_blocked_weekdays` — adds `blocked_weekdays` (JSON array, `TEXT`) to `parks`
- `026_park_week_start_day` — adds `week_start_day` (`INTEGER`, default `1`) to `parks`

**Backend**
- `park.model.ts` — serialises/deserialises `blockedWeekdays` and `weekStartDay`
- `park.routes.ts` — `GET/PUT /:id/desk-quota` exposes and validates the new fields
- `desk-booking.routes.ts` — blocks booking on closed weekdays; enforces 3-month max booking horizon; returns `blockedWeekdays`/`weekStartDay` from the quota endpoint

**Frontend**
- `DeskDatePicker.tsx` — respects `weekStartDay` for column layout and day labels; greys out blocked weekdays; disables forward navigation past the 3-month horizon
- `DesksPage.tsx` — tracks calendar view month independently from selection, reloads quota on month navigation, excludes blocked days from `bookableDates` counts and booking calls, clears selection after a successful booking
- `AdminDesksPage.tsx` — adds "Calendar Settings" section to the desk quota form: week-start-day dropdown + closed-days chip group
- `api.ts` / `types/index.ts` — passes new fields through the API layer

## Test plan

- [x] As admin: save closed days (e.g. Sat + Sun) and week start = Monday — calendar should reorder columns and grey out weekends
- [x] Attempt to book a desk on a blocked weekday via API — should return 400 "The park is closed on that day"
- [x] Attempt to book more than 3 months ahead via API — should return 400
- [x] In range/multi mode, verify blocked days are excluded from the day count and not submitted to the API
- [x] Navigate the calendar forward — next-month button should disable once the 3-month horizon is reached
- [x] Quota card title updates to the correct month as you navigate the calendar
- [x] No regressions on single-day booking, quota enforcement, or room bookings

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)