### PR TITLE
Fix TypeScript errors from @types/express@5 ParamsDictionary change

### DIFF
--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -14,6 +14,7 @@ const JWT_SECRET = process.env.JWT_SECRET || (() => {
 
 export interface AuthRequest extends Request {
   user?: JwtPayload;
+  params: Record<string, string>;
 }
 
 export function generateToken(payload: JwtPayload, keepLoggedIn?: boolean): string {

--- a/backend/src/routes/device-api.routes.ts
+++ b/backend/src/routes/device-api.routes.ts
@@ -439,7 +439,7 @@ router.get('/firmware/check', authenticateDevice, async (req: DeviceRequest, res
 router.get('/firmware/download/:version', authenticateDevice, async (req: DeviceRequest, res: Response) => {
   try {
     const device = req.device!;
-    const { version } = req.params;
+    const { version } = req.params as Record<string, string>;
 
     console.log('Firmware download request from device:', device.name, '| Requesting version:', version, '| Device type:', device.deviceType);
 

--- a/backend/src/routes/park.routes.ts
+++ b/backend/src/routes/park.routes.ts
@@ -383,7 +383,7 @@ router.post('/:id/logo', authenticate, logoUploadMiddleware, async (req: MulterA
 // Serve park logo (public)
 router.get('/:id/logo/:filename', (req: Request, res: Response) => {
   try {
-    const { filename } = req.params;
+    const { filename } = req.params as Record<string, string>;
 
     // Validate filename to prevent path traversal
     if (!/^[a-zA-Z0-9_-]+\.(png|jpg|jpeg|gif|svg|webp)$/i.test(filename)) {

--- a/backend/src/routes/sso.routes.ts
+++ b/backend/src/routes/sso.routes.ts
@@ -53,7 +53,7 @@ router.get('/discover', async (req: Request, res: Response) => {
 // GET /api/sso/init/:configId — Redirect to IdP
 router.get('/init/:configId', async (req: Request, res: Response) => {
   try {
-    const { configId } = req.params;
+    const { configId } = req.params as Record<string, string>;
     const config = await SsoConfigModel.findById(configId);
 
     if (!config || !config.isEnabled) {
@@ -124,7 +124,7 @@ router.post('/callback/saml', async (req: Request, res: Response) => {
 // GET /api/sso/saml/metadata/:configId — SP metadata XML
 router.get('/saml/metadata/:configId', async (req: Request, res: Response) => {
   try {
-    const metadata = await SsoService.generateSamlMetadata(req.params.configId);
+    const metadata = await SsoService.generateSamlMetadata(req.params['configId'] as string);
     res.type('application/xml').send(metadata);
   } catch (error: any) {
     res.status(404).json({ error: error.message });

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -29,7 +29,7 @@ const bulkImportLimiter = rateLimit({
   message: { error: 'Too many bulk import requests, please try again later.' },
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: (req: AuthRequest) => req.user?.userId ?? req.ip ?? 'unknown',
+  keyGenerator: (req: any) => req.user?.userId ?? req.ip ?? 'unknown',
 });
 
 // Get all users (admin only)


### PR DESCRIPTION
@types/express@5 changed ParamsDictionary's index signature from string to string | string[], causing 162 type errors across all route files that destructured req.params values and passed them to functions expecting string.

Fixes:
- AuthRequest: add params: Record<string, string> override to narrow the type for all AuthRequest-typed route handlers (covers ~153 errors)
- device-api.routes.ts: cast req.params for DeviceRequest route
- park.routes.ts: cast req.params for plain Request logo route
- sso.routes.ts: cast req.params for plain Request SSO routes
- user.routes.ts: fix keyGenerator callback type for rate limiter

https://claude.ai/code/session_01CdcsCUgPTTrweUdh6BSgnG