### PR TITLE
feat: temporary user suspension with session revocation and email notice

### DIFF
--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -56,10 +56,14 @@ export async function authenticate(req: AuthRequest, res: Response, next: NextFu
     return;
   }
 
-  // Verify user is still active
+  // Verify user is still active and not temporarily disabled
   const user = await UserModel.findById(payload.userId);
   if (!user || !user.isActive) {
     res.status(401).json({ error: 'Account is disabled or deleted' });
+    return;
+  }
+  if (user.disabledUntil && new Date(user.disabledUntil) > new Date()) {
+    res.status(401).json({ error: 'Account is temporarily disabled' });
     return;
   }
 

--- a/backend/src/migrations/027_user_disable.ts
+++ b/backend/src/migrations/027_user_disable.ts
@@ -1,0 +1,21 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  const hasDisabledUntil = await knex.schema.hasColumn('users', 'disabled_until');
+  if (!hasDisabledUntil) {
+    await knex.schema.table('users', (table) => {
+      table.dateTime('disabled_until').nullable().defaultTo(null);
+      table.text('disable_reason').nullable().defaultTo(null);
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasDisabledUntil = await knex.schema.hasColumn('users', 'disabled_until');
+  if (hasDisabledUntil) {
+    await knex.schema.table('users', (table) => {
+      table.dropColumn('disabled_until');
+      table.dropColumn('disable_reason');
+    });
+  }
+}

--- a/backend/src/models/user.model.ts
+++ b/backend/src/models/user.model.ts
@@ -324,9 +324,29 @@ export class UserModel {
       inviteToken: row.invite_token || null,
       inviteTokenExpiry: row.invite_token_expiry || null,
       hasSeenTour: row.has_seen_tour !== undefined ? !!row.has_seen_tour : true,
+      disabledUntil: row.disabled_until || null,
+      disableReason: row.disable_reason || null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };
+  }
+
+  static async disable(userId: string, until: string, reason: string | null): Promise<void> {
+    const db = getDb();
+    await db('users').where('id', userId).update({
+      disabled_until: until,
+      disable_reason: reason ?? null,
+      updated_at: new Date().toISOString(),
+    });
+  }
+
+  static async enable(userId: string): Promise<void> {
+    const db = getDb();
+    await db('users').where('id', userId).update({
+      disabled_until: null,
+      disable_reason: null,
+      updated_at: new Date().toISOString(),
+    });
   }
 
   static async findByInviteToken(token: string): Promise<User | null> {

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -8,7 +8,7 @@ import { CompanyModel } from '../models/company.model';
 import { TrustedDeviceModel } from '../models/trusted-device.model';
 import { BookingModel } from '../models/booking.model';
 import { UserRole } from '../types';
-import { sendUserInviteEmail } from '../services/email.service';
+import { sendUserInviteEmail, sendUserSuspensionEmail } from '../services/email.service';
 import { auditLog, AuditAction, getClientIp } from '../services/audit.service';
 
 const router = Router();
@@ -57,7 +57,9 @@ router.get('/', authenticate, requireAdmin, async (req: AuthRequest, res: Respon
       isActive: u.isActive,
       inviteToken: !!u.inviteToken,
       authSource: u.authSource,
-      createdAt: u.createdAt
+      createdAt: u.createdAt,
+      disabledUntil: u.disabledUntil,
+      disableReason: u.disableReason,
     })));
   } catch (error) {
     console.error('Get users error:', error);
@@ -94,7 +96,9 @@ router.get('/company/:companyId', authenticate, requireCompanyAdminOrAbove, asyn
       isActive: u.isActive,
       inviteToken: !!u.inviteToken,
       authSource: u.authSource,
-      createdAt: u.createdAt
+      createdAt: u.createdAt,
+      disabledUntil: u.disabledUntil,
+      disableReason: u.disableReason,
     })));
   } catch (error) {
     console.error('Get company users error:', error);
@@ -393,6 +397,79 @@ router.post('/:id/reset-2fa', authenticate, requireAdmin, async (req: AuthReques
   } catch (error) {
     console.error('Reset 2FA error:', error);
     res.status(500).json({ error: 'Failed to reset 2FA' });
+  }
+});
+
+// Temporarily disable a user (park admin+)
+router.post('/:id/disable', authenticate, requireAdmin, async (req: AuthRequest, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { until, reason } = req.body;
+
+    if (!until || isNaN(Date.parse(until))) {
+      res.status(400).json({ error: 'A valid "until" ISO datetime is required' });
+      return;
+    }
+    if (new Date(until) <= new Date()) {
+      res.status(400).json({ error: '"until" must be in the future' });
+      return;
+    }
+
+    const user = await UserModel.findById(id);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    // Cannot disable yourself
+    if (id === req.user!.userId) {
+      res.status(400).json({ error: 'Cannot disable your own account' });
+      return;
+    }
+
+    // Park admins can only disable users within their own park
+    if (req.user!.role === UserRole.PARK_ADMIN && user.parkId !== req.user!.parkId) {
+      res.status(403).json({ error: 'Park admins can only disable users within their own park' });
+      return;
+    }
+
+    await UserModel.disable(id, until, reason ?? null);
+    auditLog({ userId: req.user!.userId, action: AuditAction.USER_DISABLE, resourceType: 'user', resourceId: id, ipAddress: getClientIp(req), userAgent: req.headers['user-agent'], outcome: 'success', metadata: { until, reason: reason ?? null } });
+
+    // Notify the user by email (best-effort)
+    sendUserSuspensionEmail({ toEmail: user.email, userName: user.name, until, reason: reason ?? null })
+      .catch((err: unknown) => console.error('Failed to send suspension email:', err));
+
+    res.json({ message: 'User disabled', disabledUntil: until });
+  } catch (error) {
+    console.error('Disable user error:', error);
+    res.status(500).json({ error: 'Failed to disable user' });
+  }
+});
+
+// Re-enable a disabled user (park admin+)
+router.post('/:id/enable', authenticate, requireAdmin, async (req: AuthRequest, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const user = await UserModel.findById(id);
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    // Park admins can only enable users within their own park
+    if (req.user!.role === UserRole.PARK_ADMIN && user.parkId !== req.user!.parkId) {
+      res.status(403).json({ error: 'Park admins can only enable users within their own park' });
+      return;
+    }
+
+    await UserModel.enable(id);
+    auditLog({ userId: req.user!.userId, action: AuditAction.USER_ENABLE, resourceType: 'user', resourceId: id, ipAddress: getClientIp(req), userAgent: req.headers['user-agent'], outcome: 'success' });
+    res.json({ message: 'User enabled' });
+  } catch (error) {
+    console.error('Enable user error:', error);
+    res.status(500).json({ error: 'Failed to enable user' });
   }
 });
 

--- a/backend/src/services/audit.service.ts
+++ b/backend/src/services/audit.service.ts
@@ -55,6 +55,8 @@ export const AuditAction = {
   CALENDAR_TOKEN_REVOKE: 'calendar.token.revoke',
   // Users (additional)
   USER_2FA_RESET: 'user.2fa.reset',
+  USER_DISABLE: 'user.disable',
+  USER_ENABLE: 'user.enable',
   USER_BULK_IMPORT_START: 'user.bulk_import.start',
   USER_BULK_IMPORT_COMPLETE: 'user.bulk_import.complete',
   // Rooms

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -848,3 +848,64 @@ export async function sendUserInviteEmail(toEmail: string, inviteLink: string): 
 
   console.log(`Invite email sent to: ${toEmail}`);
 }
+
+export async function sendUserSuspensionEmail(params: {
+  toEmail: string;
+  userName: string;
+  until: string;
+  reason: string | null;
+}): Promise<void> {
+  if (!isValidEmail(params.toEmail)) {
+    console.error('Invalid email address for suspension notice:', params.toEmail);
+    return;
+  }
+
+  const untilFormatted = new Date(params.until).toLocaleString('en-GB', {
+    dateStyle: 'long',
+    timeStyle: 'short',
+  });
+
+  const reasonRow = params.reason
+    ? `<p><strong>Reason:</strong> ${params.reason}</p>`
+    : '';
+
+  const htmlContent = `
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+    .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+    .header { background: #f59e0b; color: white; padding: 20px; border-radius: 8px 8px 0 0; }
+    .content { background: #f9fafb; padding: 20px; border-radius: 0 0 8px 8px; }
+    .footer { margin-top: 20px; font-size: 12px; color: #9ca3af; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1 style="margin:0;">Your account has been suspended</h1>
+    </div>
+    <div class="content">
+      <p>Hi ${params.userName || params.toEmail},</p>
+      <p>Your Open Meeting account has been temporarily suspended by an administrator.</p>
+      ${reasonRow}
+      <p><strong>Suspended until:</strong> ${untilFormatted}</p>
+      <p>During this period you will not be able to log in or make room bookings. Your account will be restored automatically when the suspension ends.</p>
+      <p>If you believe this is a mistake, please contact your administrator.</p>
+      <p class="footer">This email was sent automatically from Open Meeting. Do not reply to this email.</p>
+    </div>
+  </div>
+</body>
+</html>
+  `;
+
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM || '"Open Meeting" <noreply@openmeeting.com>',
+    to: params.toEmail,
+    subject: 'Your Open Meeting account has been suspended',
+    html: htmlContent,
+  });
+
+  console.log(`Suspension email sent to: ${params.toEmail}`);
+}

--- a/backend/src/services/imap.service.ts
+++ b/backend/src/services/imap.service.ts
@@ -284,10 +284,11 @@ async function processMessage(rawBuffer: Buffer, room: MeetingRoom): Promise<voi
     }
   }
 
-  // 6. Sender must be an active user in the same park as the room
+  // 6. Sender must be an active, non-disabled user in the same park as the room
   const senderEmail = meeting.organizerEmail;
   const user = await UserModel.findByEmail(senderEmail);
-  if (!user || !user.isActive || user.parkId !== room.parkId) {
+  const isTemporarilyDisabled = user?.disabledUntil ? new Date(user.disabledUntil) > new Date() : false;
+  if (!user || !user.isActive || isTemporarilyDisabled || user.parkId !== room.parkId) {
     auditLog({
       action: AuditAction.BOOKING_EMAIL_REJECTED_USER,
       resourceType: 'room',

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -58,6 +58,8 @@ export interface User {
   inviteToken: string | null;
   inviteTokenExpiry: string | null;
   hasSeenTour: boolean;
+  disabledUntil: string | null;
+  disableReason: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -5,6 +5,14 @@ import { useAuth } from '../context/AuthContext';
 import { useConfirm } from '../context/ConfirmContext';
 import { BulkImportModal } from '../components/BulkImportModal';
 
+const DISABLE_DURATION_OPTIONS = [
+  { label: '1 hour', hours: 1 },
+  { label: '24 hours', hours: 24 },
+  { label: '3 days', hours: 72 },
+  { label: '7 days', hours: 168 },
+  { label: '30 days', hours: 720 },
+];
+
 export function UsersPage() {
   const { user: currentUser, isAdmin, isSuperAdmin } = useAuth();
   const showConfirm = useConfirm();
@@ -24,6 +32,9 @@ export function UsersPage() {
   });
   const [error, setError] = useState('');
   const [saving, setSaving] = useState(false);
+  const [disableTarget, setDisableTarget] = useState<User | null>(null);
+  const [disableHours, setDisableHours] = useState(24);
+  const [disableReason, setDisableReason] = useState('');
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -130,6 +141,39 @@ export function UsersPage() {
     }
   };
 
+  const handleOpenDisable = (user: User) => {
+    setDisableTarget(user);
+    setDisableHours(24);
+    setDisableReason('');
+  };
+
+  const handleDisableSubmit = async () => {
+    if (!disableTarget) return;
+    setSaving(true);
+    try {
+      const until = new Date(Date.now() + disableHours * 60 * 60 * 1000).toISOString();
+      await api.disableUser(disableTarget.id, until, disableReason || undefined);
+      setDisableTarget(null);
+      loadData();
+    } catch (err) {
+      console.error('Failed to disable user:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleEnable = async (user: User) => {
+    try {
+      await api.enableUser(user.id);
+      loadData();
+    } catch (err) {
+      console.error('Failed to enable user:', err);
+    }
+  };
+
+  const isCurrentlyDisabled = (user: User) =>
+    !!user.disabledUntil && new Date(user.disabledUntil) > new Date();
+
   const getCompanyName = (companyId: string) => {
     return companies.find(c => c.id === companyId)?.name || 'Unknown';
   };
@@ -166,7 +210,7 @@ export function UsersPage() {
           </thead>
           <tbody>
             {users.map(user => (
-              <tr key={user.id} style={user.isActive === false ? { opacity: 0.5 } : undefined}>
+              <tr key={user.id} style={user.isActive === false || isCurrentlyDisabled(user) ? { opacity: 0.5 } : undefined}>
                 <td>
                   {user.name || <em style={{ color: 'var(--text-muted)' }}>Not set up</em>}
                   {user.isActive === false && user.inviteToken && (
@@ -174,6 +218,15 @@ export function UsersPage() {
                   )}
                   {user.isActive === false && !user.inviteToken && (
                     <span className="role-badge" style={{ marginLeft: '0.25rem', background: 'var(--danger)', color: '#fff' }}>disabled</span>
+                  )}
+                  {isCurrentlyDisabled(user) && (
+                    <span
+                      className="role-badge"
+                      style={{ marginLeft: '0.25rem', background: '#f59e0b', color: '#fff', cursor: 'help' }}
+                      title={`Suspended until ${new Date(user.disabledUntil!).toLocaleString()}${user.disableReason ? ` — ${user.disableReason}` : ''}`}
+                    >
+                      suspended
+                    </span>
                   )}
                 </td>
                 <td>{user.email}</td>
@@ -211,6 +264,23 @@ export function UsersPage() {
                     >
                       Edit
                     </button>
+                    {isAdmin && user.id !== currentUser?.id && user.isActive !== false && (
+                      isCurrentlyDisabled(user) ? (
+                        <button
+                          className="btn btn-small btn-secondary"
+                          onClick={() => handleEnable(user)}
+                        >
+                          Enable
+                        </button>
+                      ) : (
+                        <button
+                          className="btn btn-small btn-warning"
+                          onClick={() => handleOpenDisable(user)}
+                        >
+                          Suspend
+                        </button>
+                      )
+                    )}
                     <button
                       className="btn btn-small btn-danger"
                       onClick={() => handleDelete(user.id)}
@@ -236,6 +306,53 @@ export function UsersPage() {
           onClose={() => setShowBulkModal(false)}
           onComplete={loadData}
         />
+      )}
+
+      {disableTarget && (
+        <div className="modal-overlay" onClick={() => setDisableTarget(null)}>
+          <div className="modal" onClick={e => e.stopPropagation()}>
+            <div className="modal-header">
+              <h2>Suspend User</h2>
+              <button className="modal-close" onClick={() => setDisableTarget(null)} aria-label="Close">×</button>
+            </div>
+            <div className="modal-body">
+              <p style={{ marginBottom: '1rem' }}>
+                Suspending <strong>{disableTarget.name || disableTarget.email}</strong> will immediately revoke their active sessions and block email-based bookings for the selected period.
+              </p>
+              <div className="form-group">
+                <label htmlFor="disableDuration">Duration</label>
+                <select
+                  id="disableDuration"
+                  value={disableHours}
+                  onChange={e => setDisableHours(Number(e.target.value))}
+                >
+                  {DISABLE_DURATION_OPTIONS.map(opt => (
+                    <option key={opt.hours} value={opt.hours}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-group">
+                <label htmlFor="disableReason">Reason (optional)</label>
+                <input
+                  type="text"
+                  id="disableReason"
+                  value={disableReason}
+                  onChange={e => setDisableReason(e.target.value)}
+                  placeholder="e.g. repeated misuse of booking system"
+                  maxLength={200}
+                />
+              </div>
+            </div>
+            <div className="modal-footer">
+              <button type="button" className="btn btn-secondary" onClick={() => setDisableTarget(null)}>
+                Cancel
+              </button>
+              <button type="button" className="btn btn-warning" onClick={handleDisableSubmit} disabled={saving}>
+                {saving ? 'Suspending...' : 'Suspend User'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {showModal && (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -380,6 +380,17 @@ class ApiService {
     await this.request(`/users/${id}/resend-invite`, { method: 'POST' });
   }
 
+  async disableUser(id: string, until: string, reason?: string): Promise<void> {
+    await this.request(`/users/${id}/disable`, {
+      method: 'POST',
+      body: JSON.stringify({ until, reason: reason || null }),
+    });
+  }
+
+  async enableUser(id: string): Promise<void> {
+    await this.request(`/users/${id}/enable`, { method: 'POST' });
+  }
+
   async bulkImportUsers(users: Array<{ email: string; name?: string; role: string; companyId?: string; companyName?: string }>): Promise<{
     results: Array<{ email: string; status: 'created' | 'skipped'; error?: string; userId?: string; companyCreated?: boolean }>;
     created: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -47,6 +47,8 @@ export interface User {
   inviteToken?: boolean | string | null;
   hasSeenTour?: boolean;
   deskBookingEnabled?: boolean;
+  disabledUntil?: string | null;
+  disableReason?: string | null;
   createdAt?: string;
 }
 


### PR DESCRIPTION
Adds the ability for park admins to temporarily suspend users in case of misuse. Suspended users are immediately blocked from all API access (effective logout via 401) and from booking via iMIP email. The user receives an email notification with the reason and suspension end time.

- Migration 027: adds disabled_until and disable_reason columns to users
- UserModel: disable(until, reason) and enable() methods
- Auth middleware: rejects requests from suspended users with 401
- iMIP service: blocks suspended users from email-based bookings
- Audit: USER_DISABLE and USER_ENABLE actions
- Routes: POST /users/:id/disable and POST /users/:id/enable (park admin+)
- Email: sendUserSuspensionEmail notifies the user with reason and expiry
- Frontend: Suspend button with duration picker (1h–30d) + optional reason; amber suspended badge with tooltip; Enable button to lift suspension early